### PR TITLE
Rename UNIT_TESTS to DISABLE_TESTS for travis integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ ENDIF()
 SETUP_PROJECT()
 
 option(PYTHON_BINDING "Generate python binding." OFF)
-option(UNIT_TESTS "Generate unit tests." ON)
+option(DISABLE_TESTS "Disable unit tests." OFF)
 option(BENCHMARKS "Generate benchmark." OFF)
 
 SET(Eigen_REQUIRED "eigen3 >= 3.2.0")
@@ -50,7 +50,7 @@ ENDIF(MSVC)
 
 add_subdirectory(src)
 
-if(${UNIT_TESTS} OR ${BENCHMARKS})
+if(NOT ${DISABLE_TESTS} OR ${BENCHMARKS})
   add_subdirectory(tests)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories("${PROJECT_SOURCE_DIR}/src")
 include_directories(${Boost_INCLUDE_DIRS})
 
 macro(addUnitTest name)
-  if(${UNIT_TESTS})
+  if(NOT ${DISABLE_TESTS})
     add_executable(${name} ${name}.cpp ${HEADERS})
     target_link_libraries(${name} ${Boost_LIBRARIES})
     add_test(${name}Unit ${name})


### PR DESCRIPTION
I think the title says it all, this is useful when pulling SpaceVecAlg as a dependency, and avoids building tests.