### PR TITLE
Add an option to force Python 3 usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ SETUP_PROJECT()
 
 option(PYTHON_BINDING "Generate python binding." ON)
 option(PYTHON_BINDING_USER_INSTALL "Install the Python bindings in user space" OFF)
+option(PYTHON_BINDING_FORCE_PYTHON3 "Use pip3/python3 instead of pip/python" OFF)
 option(DISABLE_TESTS "Disable unit tests." OFF)
 option(BENCHMARKS "Generate benchmark." OFF)
 

--- a/binding/python/CMakeLists.txt
+++ b/binding/python/CMakeLists.txt
@@ -28,15 +28,22 @@ GET_SVA_PROPERTY(LINK_LIBRARIES)
 GET_SVA_PROPERTY(LOCATION)
 CONFIGURE_FILE(setup.in.py ${CMAKE_CURRENT_SOURCE_DIR}/setup.py)
 
+SET(PYTHON "python")
+SET(PIP "pip")
+IF(${PYTHON_BINDING_FORCE_PYTHON3})
+  SET(PYTHON "python3")
+  SET(PIP "pip3")
+ENDIF()
+
 # Build the bindings locally at build time for test purposes
 ADD_CUSTOM_TARGET(sva-python-bindings ALL
-  COMMAND python setup.py build_ext --inplace
+  COMMAND ${PYTHON} setup.py build_ext --inplace
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Generating local SpaceVecAlg Python bindings"
   DEPENDS include/sva_wrapper.hpp sva/c_sva.pxd sva/sva.pxd sva/sva.pyx
 )
 
-if(NOT ${DISABLE_TESTS})
+IF(NOT ${DISABLE_TESTS})
   ADD_CUSTOM_TARGET(test-sva-python-bindings
     COMMAND nosetests
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -62,7 +69,7 @@ IF(DEFINED PYTHON_DEB_ROOT)
   )
 ELSE()
   ADD_CUSTOM_TARGET(install-sva-python-bindings
-    COMMAND pip install ${PIP_EXTRA_OPTIONS} .
+    COMMAND ${PIP} install ${PIP_EXTRA_OPTIONS} .
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Install SpaceVecAlg Python bindings"
   )


### PR DESCRIPTION
This PR adds an option to use `python3` and `pip3` rather than `python` and `pip` in the related binding compilation/installation commands.