### PR TITLE
 Admittance and impedance vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.pyc
 binding/python/sva/__init__.py
 binding/python/sva/sva.cpp
-binding/python/sva/sva.so
+binding/python/sva/*.so
 binding/python/setup.py
 binding/python/build
 *.swp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@
 # along with SpaceVecAlg.  If not, see <http://www.gnu.org/licenses/>.
 
 version: 1.0.{build}
-os: Visual Studio 2015
+image: Visual Studio 2015
 clone_folder: C:/devel-src/SpaceVecAlg
 environment:
   CI_OS_NAME: win32
@@ -28,10 +28,10 @@ environment:
 # Do not tinker with the variables below unless you know what you are doing
   SOURCE_FOLDER: C:\devel-src
   CMAKE_INSTALL_PREFIX: C:/devel
-  PATH: C:/devel/bin;C:\Libraries\boost_1_59_0\lib64-msvc-14.0;C:\msys64\mingw64\bin;%PATH%
+  PATH: C:/devel/bin;C:\Libraries\boost_1_67_0\lib64-msvc-14.0;C:\msys64\mingw64\bin;%PATH%
   PKG_CONFIG_PATH: C:/devel/lib/pkgconfig
-  BOOST_ROOT: C:\Libraries\boost_1_59_0
-  BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14.0
+  BOOST_ROOT: C:\Libraries\boost_1_67_0
+  BOOST_LIBRARYDIR: C:\Libraries\boost_1_67_0\lib64-msvc-14.0
   MINGW_GFORTRAN: C:\msys64\mingw64\bin\gfortran.exe
 build_script:
 - ps: >-
@@ -55,3 +55,7 @@ test_script:
 #     reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication /t REG_DWORD /d 0 /f
 # 
 #     $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+notifications:
+  - provider: Slack
+    incoming_webhook:
+      secure: gAze73sSl1vrNGaeUEd841yVJ/rVE10tIWjlt+/8OPn0lT42+nSjNqS3bSNgmS+UwyZNe0vzpBTCl6Lx3JEltYNoad96Ss31BEm/7MNLxgc=

--- a/binding/python/include/sva_wrapper.hpp
+++ b/binding/python/include/sva_wrapper.hpp
@@ -22,6 +22,20 @@
 namespace sva
 {
 
+std::string AdmittanceVecdToString(const sva::AdmittanceVecd & av)
+{
+  std::stringstream ss;
+  ss << av;
+  return ss.str();
+}
+
+std::string ImpedanceVecdToString(const sva::ImpedanceVecd & iv)
+{
+  std::stringstream ss;
+  ss << iv;
+  return ss.str();
+}
+
 template<typename T>
 std::string ForceVecToString(const sva::ForceVec<T> & m)
 {
@@ -190,6 +204,70 @@ sva::PTransform<double>& const_cast_ptd(const sva::PTransform<double> & rhs)
 std::vector<sva::PTransformd>& const_cast_pt_vec(const std::vector<sva::PTransformd> & rhs)
 {
   return const_cast<std::vector<sva::PTransformd>&>(rhs);
+}
+
+ForceVecd ForceVecdZero()
+{
+  return ForceVecd::Zero();
+}
+
+MotionVecd MotionVecdZero()
+{
+  return MotionVecd::Zero();
+}
+
+AdmittanceVecd AdmittanceVecdZero()
+{
+  return AdmittanceVecd::Zero();
+}
+
+ImpedanceVecd ImpedanceVecdZero()
+{
+  return ImpedanceVecd::Zero();
+}
+
+AdmittanceVecd AdmittanceVecdHomo(double a, double l)
+{
+  return AdmittanceVecd(a, l);
+}
+
+ImpedanceVecd ImpedanceVecdHomo(double a, double l)
+{
+  return ImpedanceVecd(a, l);
+}
+
+MotionVecd mul_av_fv(AdmittanceVecd & lhs, ForceVecd & rhs)
+{
+  return lhs * rhs;
+}
+void av_iadd(AdmittanceVecd & lhs, AdmittanceVecd & rhs)
+{
+  lhs += rhs;
+}
+void av_imul(AdmittanceVecd & lhs, double s)
+{
+  lhs *= s;
+}
+void av_idiv(AdmittanceVecd & lhs, double s)
+{
+  lhs /= s;
+}
+
+ForceVecd mul_iv_mv(ImpedanceVecd & lhs, MotionVecd & rhs)
+{
+  return lhs * rhs;
+}
+void iv_iadd(ImpedanceVecd & lhs, ImpedanceVecd & rhs)
+{
+  lhs += rhs;
+}
+void iv_imul(ImpedanceVecd & lhs, double s)
+{
+  lhs *= s;
+}
+void iv_idiv(ImpedanceVecd & lhs, double s)
+{
+  lhs /= s;
 }
 
 }

--- a/binding/python/sva/c_sva.pxd
+++ b/binding/python/sva/c_sva.pxd
@@ -21,6 +21,42 @@ from libcpp.vector cimport vector
 from libcpp cimport bool
 
 cdef extern from "<SpaceVecAlg/SpaceVecAlg>" namespace "sva":
+  cdef cppclass AdmittanceVec[T]:
+    AdmittanceVec()
+    AdmittanceVec(const AdmittanceVec[T] &)
+    AdmittanceVec(const c_eigen.Matrix[T,c_eigen.six,c_eigen.one]&)
+    AdmittanceVec(const c_eigen.Matrix[T,c_eigen.three,c_eigen.one]&,
+                  const c_eigen.Matrix[T,c_eigen.three,c_eigen.one]&)
+
+    c_eigen.Matrix[T,c_eigen.three,c_eigen.one] angular() const
+    c_eigen.Matrix[T,c_eigen.three,c_eigen.one] linear() const
+    c_eigen.Matrix[T,c_eigen.six,c_eigen.one] vector() const
+
+    AdmittanceVec[T] operator+(const AdmittanceVec[T] &)
+    AdmittanceVec[T] operator*(const T &)
+    AdmittanceVec[T] operator/(const T &)
+
+    bool operator==(const AdmittanceVec[T] &)
+    bool operator!=(const AdmittanceVec[T] &)
+
+  cdef cppclass ImpedanceVec[T]:
+    ImpedanceVec()
+    ImpedanceVec(const ImpedanceVec[T] &)
+    ImpedanceVec(const c_eigen.Matrix[T,c_eigen.six,c_eigen.one]&)
+    ImpedanceVec(const c_eigen.Matrix[T,c_eigen.three,c_eigen.one]&,
+                 const c_eigen.Matrix[T,c_eigen.three,c_eigen.one]&)
+
+    c_eigen.Matrix[T,c_eigen.three,c_eigen.one] angular() const
+    c_eigen.Matrix[T,c_eigen.three,c_eigen.one] linear() const
+    c_eigen.Matrix[T,c_eigen.six,c_eigen.one] vector() const
+
+    ImpedanceVec[T] operator+(const ImpedanceVec[T] &)
+    ImpedanceVec[T] operator*(const T &)
+    ImpedanceVec[T] operator/(const T &)
+
+    bool operator==(const ImpedanceVec[T] &)
+    bool operator!=(const ImpedanceVec[T] &)
+
   cdef cppclass ForceVec[T]:
     ForceVec()
     ForceVec(const ForceVec[T] &)
@@ -29,6 +65,7 @@ cdef extern from "<SpaceVecAlg/SpaceVecAlg>" namespace "sva":
              const c_eigen.Matrix[T,c_eigen.three,c_eigen.one]&)
 
     c_eigen.Matrix[T,c_eigen.three,c_eigen.one] couple() const
+    c_eigen.Matrix[T,c_eigen.three,c_eigen.one] moment() const
     c_eigen.Matrix[T,c_eigen.three,c_eigen.one] force() const
     c_eigen.Matrix[T,c_eigen.six,c_eigen.one] vector() const
 
@@ -156,6 +193,8 @@ cdef extern from "<SpaceVecAlg/SpaceVecAlg>" namespace "sva":
     bool operator==(const PTransform[T]&)
     bool operator!=(const PTransform[T]&)
 
+  ctypedef AdmittanceVec[double] AdmittanceVecd
+  ctypedef ImpedanceVec[double] ImpedanceVecd
   ctypedef ForceVec[double] ForceVecd
   ctypedef MotionVec[double] MotionVecd
   ctypedef RBInertia[double] RBInertiad

--- a/binding/python/sva/c_sva_private.pxd
+++ b/binding/python/sva/c_sva_private.pxd
@@ -21,6 +21,8 @@ from libcpp.vector cimport vector
 from libcpp cimport bool
 
 cdef extern from "sva_wrapper.hpp" namespace "sva":
+  string AdmittanceVecdToString(const AdmittanceVecd &)
+  string ImpedanceVecdToString(const ImpedanceVecd &)
   string ForceVecToString[T](const ForceVec[T] &)
   string MotionVecToString[T](const MotionVec[T] &)
   string RBInertiaToString[T](const RBInertia[T] &)
@@ -31,17 +33,33 @@ cdef extern from "sva_wrapper.hpp" namespace "sva":
 
   PTransformd * NewPTransformdFromV3(const c_eigen.Matrix[double, c_eigen.three, c_eigen.one]&)
 
+  MotionVecd mul_av_fv(AdmittanceVecd & lhs, ForceVecd & rhs)
+  void av_iadd(AdmittanceVecd & lhs, AdmittanceVecd & rhs)
+  void av_imul(AdmittanceVecd & lhs, double s)
+  void av_idiv(AdmittanceVecd & lhs, double s)
+  AdmittanceVecd AdmittanceVecdZero()
+  AdmittanceVecd AdmittanceVecdHomo(double, double)
+
+  ForceVecd mul_iv_mv(ImpedanceVecd & lhs, MotionVecd & rhs)
+  void iv_iadd(ImpedanceVecd & lhs, ImpedanceVecd & rhs)
+  void iv_imul(ImpedanceVecd & lhs, double s)
+  void iv_idiv(ImpedanceVecd & lhs, double s)
+  ImpedanceVecd ImpedanceVecdZero()
+  ImpedanceVecd ImpedanceVecdHomo(double, double)
+
   ForceVecd & const_cast_fvd(const ForceVecd &)
   void fv_iadd[T](ForceVec[T] * lhs, ForceVec[T] * rhs)
   void fv_isub[T](ForceVec[T] * lhs, ForceVec[T] * rhs)
   void fv_imul[T](ForceVec[T] * lhs, double s)
   void fv_idiv[T](ForceVec[T] * lhs, double s)
+  ForceVecd ForceVecdZero()
 
   MotionVecd & const_cast_mvd(const MotionVecd &)
   void mv_iadd[T](MotionVec[T] * lhs, MotionVec[T] * rhs)
   void mv_isub[T](MotionVec[T] * lhs, MotionVec[T] * rhs)
   void mv_imul[T](MotionVec[T] * lhs, double s)
   void mv_idiv[T](MotionVec[T] * lhs, double s)
+  MotionVecd MotionVecdZero()
 
   RBInertiad & const_cast_rbid(const RBInertiad &)
   void rbi_iadd[T](RBInertia[T] * lhs, RBInertia[T] * rhs)

--- a/binding/python/sva/sva.pxd
+++ b/binding/python/sva/sva.pxd
@@ -20,6 +20,16 @@ cimport c_sva
 from libcpp.vector cimport vector
 from libcpp cimport bool as cppbool
 
+cdef class AdmittanceVecd(object):
+  cdef c_sva.AdmittanceVecd impl
+
+cdef AdmittanceVecd AdmittanceVecdFromC(const c_sva.AdmittanceVecd&)
+
+cdef class ImpedanceVecd(object):
+  cdef c_sva.ImpedanceVecd impl
+
+cdef ImpedanceVecd ImpedanceVecdFromC(const c_sva.ImpedanceVecd&)
+
 cdef class ForceVecd(object):
   cdef c_sva.ForceVecd * impl
   cdef cppbool __own_impl

--- a/binding/python/sva/sva.pyx
+++ b/binding/python/sva/sva.pyx
@@ -267,6 +267,8 @@ cdef class ForceVecd(object):
     return ForceVecdFromC(deref(self.impl)*s)
   def __mul__(self, other):
     if isinstance(self, ForceVecd):
+      if isinstance(other, AdmittanceVecd):
+        return other.__mul__(self)
       return self.__mul(other)
     else:
       return other.__mul__(self)
@@ -385,6 +387,8 @@ cdef class MotionVecd(object):
     return MotionVecdFromC(deref(self.impl)*s)
   def __mul__(self, other):
     if isinstance(self, MotionVecd):
+      if isinstance(other, ImpedanceVecd):
+        return other.__mul__(self)
       return self.__mul(other)
     else:
       return other.__mul__(self)

--- a/binding/python/sva/sva.pyx
+++ b/binding/python/sva/sva.pyx
@@ -24,6 +24,182 @@ cimport eigen.eigen as eigen
 from libcpp.vector cimport vector
 from cython.operator cimport dereference as deref
 
+cdef class AdmittanceVecd(object):
+  def __copyctor__(self, AdmittanceVecd other):
+    self.impl = c_sva.AdmittanceVecd(other.impl)
+  def __v6ctor__(self, eigen.Vector6d other):
+    self.impl = c_sva.AdmittanceVecd(other.impl)
+  def __v3v3ctor__(self, eigen.Vector3d angular, eigen.Vector3d linear):
+    self.impl = c_sva.AdmittanceVecd(angular.impl, linear.impl)
+  def __homoctor__(self, double angular, double linear):
+    self.impl = c_sva_private.AdmittanceVecdHomo(angular, linear)
+  def __cinit__(self, *args, skip_alloc = False):
+    if len(args) == 0:
+      self.impl = c_sva.AdmittanceVecd()
+    elif len(args) == 1 and isinstance(args[0], AdmittanceVecd):
+      self.__copyctor__(args[0])
+    elif len(args) == 1 and isinstance(args[0], eigen.Vector6d):
+      self.__v6ctor__(args[0])
+    elif len(args) == 2 and isinstance(args[0], eigen.Vector3d) and isinstance(args[1], eigen.Vector3d):
+      self.__v3v3ctor__(args[0], args[1])
+    elif len(args) == 2 and isinstance(args[0], list) and isinstance(args[1], list):
+      self.__v3v3ctor__(eigen.Vector3d(args[0]), eigen.Vector3d(args[1]))
+    elif len(args) == 2:
+      self.__homoctor__(args[0], args[1])
+    else:
+      raise TypeError("Invalid arguments passed to AdmittanceVecd ctor")
+
+  def angular(self):
+    return eigen.Vector3dFromC(<c_eigen.Vector3d>self.impl.angular())
+  def linear(self):
+    return eigen.Vector3dFromC(<c_eigen.Vector3d>self.impl.linear())
+  def vector(self):
+    return eigen.Vector6dFromC(<c_eigen.Vector6d>self.impl.vector())
+
+  def __repr__(self):
+    return "sva.AdmittanceVecd"
+  def __str__(self):
+    return c_sva_private.AdmittanceVecdToString(self.impl)
+
+  def __add__(AdmittanceVecd self, AdmittanceVecd other):
+    return AdmittanceVecdFromC(self.impl + other.impl)
+  def __iadd__(self, AdmittanceVecd other):
+    c_sva_private.av_iadd(self.impl, other.impl)
+    return self
+
+  def __mul(self, double s):
+    return AdmittanceVecdFromC(self.impl*s)
+  def __mul_fv(self, ForceVecd fv):
+    return MotionVecdFromC(c_sva_private.mul_av_fv(self.impl, deref(fv.impl)))
+  def __mul__(self, other):
+    if isinstance(self, AdmittanceVecd):
+      if isinstance(other, ForceVecd):
+        return self.__mul_fv(other)
+      return self.__mul(other)
+    else:
+      return other.__mul__(self)
+  def __imul__(self, double other):
+    c_sva_private.av_imul(self.impl, other)
+    return self
+
+  def __div__(AdmittanceVecd self, double other):
+    return self.__truediv__(other)
+  def __truediv__(AdmittanceVecd self, double other):
+    return AdmittanceVecdFromC(self.impl/other)
+  def __idiv__(self, double other):
+    return self.__itruediv__(other)
+  def __itruediv__(self, double other):
+    c_sva_private.av_idiv(self.impl, other)
+    return self
+
+  def __richcmp__(AdmittanceVecd self, AdmittanceVecd other, int op):
+    if op == 2:
+      return self.impl == other.impl
+    elif op == 3:
+      return self.impl != other.impl
+    else:
+      raise NotImplementedError("This comparison is not supported")
+
+  @staticmethod
+  def Zero():
+    return AdmittanceVecdFromC(c_sva_private.AdmittanceVecdZero())
+  @staticmethod
+  def pickle(mv):
+    return AdmittanceVecd, (list(mv.angular()), list(mv.linear()))
+
+cdef AdmittanceVecd AdmittanceVecdFromC(const c_sva.AdmittanceVecd& av):
+  cdef AdmittanceVecd ret = AdmittanceVecd()
+  ret.impl = av
+  return ret
+
+cdef class ImpedanceVecd(object):
+  def __copyctor__(self, ImpedanceVecd other):
+    self.impl = c_sva.ImpedanceVecd(other.impl)
+  def __v6ctor__(self, eigen.Vector6d other):
+    self.impl = c_sva.ImpedanceVecd(other.impl)
+  def __v3v3ctor__(self, eigen.Vector3d angular, eigen.Vector3d linear):
+    self.impl = c_sva.ImpedanceVecd(angular.impl, linear.impl)
+  def __homoctor__(self, double angular, double linear):
+    self.impl = c_sva_private.ImpedanceVecdHomo(angular, linear)
+  def __cinit__(self, *args, skip_alloc = False):
+    if len(args) == 0:
+      self.impl = c_sva.ImpedanceVecd()
+    elif len(args) == 1 and isinstance(args[0], ImpedanceVecd):
+      self.__copyctor__(args[0])
+    elif len(args) == 1 and isinstance(args[0], eigen.Vector6d):
+      self.__v6ctor__(args[0])
+    elif len(args) == 2 and isinstance(args[0], eigen.Vector3d) and isinstance(args[1], eigen.Vector3d):
+      self.__v3v3ctor__(args[0], args[1])
+    elif len(args) == 2 and isinstance(args[0], list) and isinstance(args[1], list):
+      self.__v3v3ctor__(eigen.Vector3d(args[0]), eigen.Vector3d(args[1]))
+    elif len(args) == 2:
+      self.__homoctor__(args[0], args[1])
+    else:
+      raise TypeError("Invalid arguments passed to ImpedanceVecd ctor")
+
+  def angular(self):
+    return eigen.Vector3dFromC(<c_eigen.Vector3d>self.impl.angular())
+  def linear(self):
+    return eigen.Vector3dFromC(<c_eigen.Vector3d>self.impl.linear())
+  def vector(self):
+    return eigen.Vector6dFromC(<c_eigen.Vector6d>self.impl.vector())
+
+  def __repr__(self):
+    return "sva.ImpedanceVecd"
+  def __str__(self):
+    return c_sva_private.ImpedanceVecdToString(self.impl)
+
+  def __add__(ImpedanceVecd self, ImpedanceVecd other):
+    return ImpedanceVecdFromC(self.impl + other.impl)
+  def __iadd__(self, ImpedanceVecd other):
+    c_sva_private.iv_iadd(self.impl, other.impl)
+    return self
+
+  def __mul(self, double s):
+    return ImpedanceVecdFromC(self.impl*s)
+  def __mul_mv(self, MotionVecd mv):
+    return ForceVecdFromC(c_sva_private.mul_iv_mv(self.impl, deref(mv.impl)))
+  def __mul__(self, other):
+    if isinstance(self, ImpedanceVecd):
+      if isinstance(other, MotionVecd):
+        return self.__mul_mv(other)
+      return self.__mul(other)
+    else:
+      return other.__mul__(self)
+  def __imul__(self, double other):
+    c_sva_private.iv_imul(self.impl, other)
+    return self
+
+  def __div__(ImpedanceVecd self, double other):
+    return self.__truediv__(other)
+  def __truediv__(ImpedanceVecd self, double other):
+    return ImpedanceVecdFromC(self.impl/other)
+  def __idiv__(self, double other):
+    return self.__itruediv__(other)
+  def __itruediv__(self, double other):
+    c_sva_private.iv_idiv(self.impl, other)
+    return self
+
+  def __richcmp__(ImpedanceVecd self, ImpedanceVecd other, int op):
+    if op == 2:
+      return self.impl == other.impl
+    elif op == 3:
+      return self.impl != other.impl
+    else:
+      raise NotImplementedError("This comparison is not supported")
+
+  @staticmethod
+  def Zero():
+    return ImpedanceVecdFromC(c_sva_private.ImpedanceVecdZero())
+  @staticmethod
+  def pickle(mv):
+    return ImpedanceVecd, (list(mv.angular()), list(mv.linear()))
+
+cdef ImpedanceVecd ImpedanceVecdFromC(const c_sva.ImpedanceVecd& iv):
+  cdef ImpedanceVecd ret = ImpedanceVecd()
+  ret.impl = iv
+  return ret
+
 cdef class ForceVecd(object):
   def __dealloc__(self):
     if self.__own_impl:
@@ -53,6 +229,10 @@ cdef class ForceVecd(object):
   def couple(self):
     cdef eigen.Vector3d ret = eigen.Vector3d()
     ret.impl = <c_eigen.Vector3d>(self.impl.couple())
+    return ret
+  def moment(self):
+    cdef eigen.Vector3d ret = eigen.Vector3d()
+    ret.impl = <c_eigen.Vector3d>(self.impl.moment())
     return ret
   def force(self):
     cdef eigen.Vector3d ret = eigen.Vector3d()
@@ -112,6 +292,9 @@ cdef class ForceVecd(object):
     else:
       raise NotImplementedError("This comparison is not supported")
 
+  @staticmethod
+  def Zero():
+    return ForceVecdFromC(c_sva_private.ForceVecdZero())
   @staticmethod
   def pickle(fv):
     return ForceVecd, (list(fv.couple()), list(fv.force()))
@@ -227,6 +410,9 @@ cdef class MotionVecd(object):
     else:
       raise NotImplementedError("This comparison is not supported")
 
+  @staticmethod
+  def Zero():
+    return MotionVecdFromC(c_sva_private.MotionVecdZero())
   @staticmethod
   def pickle(mv):
     return MotionVecd, (list(mv.angular()), list(mv.linear()))

--- a/binding/python/tests/test_sva_vector.py
+++ b/binding/python/tests/test_sva_vector.py
@@ -68,6 +68,9 @@ class TestMotionVecd(unittest.TestCase):
     self.assertTrue(vec != (-vec))
     self.assertTrue(not(vec != vec))
 
+    z = sva.MotionVecd([0, 0, 0], [0, 0, 0])
+    self.assertEqual(sva.MotionVecd.Zero(), z)
+
 class TestForceVecd(unittest.TestCase):
   def test(self):
     n = eigen.Vector3d.Random()
@@ -108,6 +111,9 @@ class TestForceVecd(unittest.TestCase):
     self.assertTrue(vec != (-vec))
     self.assertTrue(not(vec != vec))
 
+    z = sva.ForceVecd([0, 0, 0], [0, 0, 0])
+    self.assertEqual(sva.ForceVecd.Zero(), z)
+
 class TestMotionVecdLeftOperatorsTest(unittest.TestCase):
   def test(self):
     w = eigen.Vector3d.Random()*100
@@ -137,9 +143,114 @@ class TestMotionVecdLeftOperatorsTest(unittest.TestCase):
     self.assertTrue(isinstance(crossF, sva.ForceVecd))
     self.assertAlmostEqual((crossF.vector() - sva.vector6ToCrossDualMatrix(mm)*mf).norm(), 0, delta = TOL)
 
+class TestImpedanceVecd(unittest.TestCase):
+  def test(self):
+    w = eigen.Vector3d.Random()
+    v = eigen.Vector3d.Random()
+    vec = sva.ImpedanceVecd(w, v)
+    z = vec.vector()
+
+    self.assertEqual(w, vec.angular())
+    self.assertEqual(v, vec.linear())
+    self.assertEqual(z, eigen.Vector6d(w.x(), w.y(), w.z(), v.x(), v.y(), v.z()))
+
+    self.assertEqual((5.*vec).vector(), 5.*z)
+    self.assertEqual((vec*5.).vector(), 5.*z)
+    self.assertEqual((vec/5.).vector(), z/5.)
+
+    vec *= 5.
+    self.assertEqual(vec.vector(), 5.*z)
+    vec /= 5.
+    [ self.assertAlmostEqual(x, 0, delta = TOL) for x in vec.vector() - z ]
+
+    w2 = eigen.Vector3d.Random()
+    v2 = eigen.Vector3d.Random()
+    vec2 = sva.ImpedanceVecd(w2, v2)
+    z2 = vec2.vector()
+
+    self.assertEqual((vec + vec2).vector(), z + z2)
+
+    vec_pluseq = sva.ImpedanceVecd(vec)
+    self.assertEqual(vec_pluseq, vec)
+    vec_pluseq += vec2
+    self.assertEqual(vec_pluseq, vec + vec2)
+
+    self.assertEqual(vec, vec)
+    self.assertTrue(not (vec != vec))
+
+    w = eigen.Vector3d.Random()
+    v = eigen.Vector3d.Random()
+    mv = sva.MotionVecd(eigen.Vector3d.Random(), eigen.Vector3d.Random())
+
+    fv = vec * mv
+    self.assertTrue(isinstance(fv, sva.ForceVecd))
+    res = eigen.Vector6d([ x*y for x,y in zip(vec.vector(), mv.vector()) ])
+    self.assertEqual(res, fv.vector())
+
+    hv = sva.ImpedanceVecd(11., 42.)
+    self.assertEqual(hv.angular(), eigen.Vector3d(11., 11., 11.))
+    self.assertEqual(hv.linear(), eigen.Vector3d(42., 42., 42.))
+
+    z = sva.ImpedanceVecd(0., 0.)
+    self.assertEqual(sva.ImpedanceVecd.Zero(), z)
+
+class TestAdmittanceVecd(unittest.TestCase):
+  def test(self):
+    w = eigen.Vector3d.Random()
+    v = eigen.Vector3d.Random()
+    vec = sva.AdmittanceVecd(w, v)
+    z = vec.vector()
+
+    self.assertEqual(w, vec.angular())
+    self.assertEqual(v, vec.linear())
+    self.assertEqual(z, eigen.Vector6d(w.x(), w.y(), w.z(), v.x(), v.y(), v.z()))
+
+    self.assertEqual((5.*vec).vector(), 5.*z)
+    self.assertEqual((vec*5.).vector(), 5.*z)
+    self.assertEqual((vec/5.).vector(), z/5.)
+
+    vec *= 5.
+    self.assertEqual(vec.vector(), 5.*z)
+    vec /= 5.
+    [ self.assertAlmostEqual(x, 0, delta = TOL) for x in vec.vector() - z ]
+
+    w2 = eigen.Vector3d.Random()
+    v2 = eigen.Vector3d.Random()
+    vec2 = sva.AdmittanceVecd(w2, v2)
+    z2 = vec2.vector()
+
+    self.assertEqual((vec + vec2).vector(), z + z2)
+
+    vec_pluseq = sva.AdmittanceVecd(vec)
+    self.assertEqual(vec_pluseq, vec)
+    vec_pluseq += vec2
+    self.assertEqual(vec_pluseq, vec + vec2)
+
+    self.assertEqual(vec, vec)
+    self.assertTrue(not (vec != vec))
+
+    w = eigen.Vector3d.Random()
+    v = eigen.Vector3d.Random()
+    fv = sva.ForceVecd(eigen.Vector3d.Random(), eigen.Vector3d.Random())
+
+    mv = vec * fv
+    self.assertTrue(isinstance(mv, sva.MotionVecd))
+    res = eigen.Vector6d([ x*y for x,y in zip(vec.vector(), fv.vector()) ])
+    self.assertEqual(res, mv.vector())
+
+    hv = sva.AdmittanceVecd(11., 42.)
+    self.assertEqual(hv.angular(), eigen.Vector3d(11., 11., 11.))
+    self.assertEqual(hv.linear(), eigen.Vector3d(42., 42., 42.))
+
+    z = sva.AdmittanceVecd(0., 0.)
+    self.assertEqual(sva.AdmittanceVecd.Zero(), z)
+
+
 if __name__ == "__main__":
   suite = unittest.TestSuite()
   suite.addTest(TestMotionVecd('test'))
   suite.addTest(TestForceVecd('test'))
   suite.addTest(TestMotionVecdLeftOperatorsTest('test'))
+  suite.addTest(TestImpedanceVecd('test'))
+  suite.addTest(TestAdmittanceVecd('test'))
   unittest.TextTestRunner(verbosity=2).run(suite)

--- a/binding/python/tests/test_sva_vector.py
+++ b/binding/python/tests/test_sva_vector.py
@@ -187,6 +187,9 @@ class TestImpedanceVecd(unittest.TestCase):
     res = eigen.Vector6d([ x*y for x,y in zip(vec.vector(), mv.vector()) ])
     self.assertEqual(res, fv.vector())
 
+    fv2 = mv * vec
+    self.assertEqual(fv, fv2)
+
     hv = sva.ImpedanceVecd(11., 42.)
     self.assertEqual(hv.angular(), eigen.Vector3d(11., 11., 11.))
     self.assertEqual(hv.linear(), eigen.Vector3d(42., 42., 42.))
@@ -237,6 +240,9 @@ class TestAdmittanceVecd(unittest.TestCase):
     self.assertTrue(isinstance(mv, sva.MotionVecd))
     res = eigen.Vector6d([ x*y for x,y in zip(vec.vector(), fv.vector()) ])
     self.assertEqual(res, mv.vector())
+
+    mv2 = fv * vec
+    self.assertEqual(mv, mv2)
 
     hv = sva.AdmittanceVecd(11., 42.)
     self.assertEqual(hv.angular(), eigen.Vector3d(11., 11., 11.))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,8 @@
 set(SOURCES lib.cpp)
 set(HEADERS SpaceVecAlg/MotionVec.h
             SpaceVecAlg/ForceVec.h
+            SpaceVecAlg/ImpedanceVec.h
+            SpaceVecAlg/AdmittanceVec.h
             SpaceVecAlg/PTransform.h
             SpaceVecAlg/RBInertia.h
             SpaceVecAlg/ABInertia.h

--- a/src/SpaceVecAlg/AdmittanceVec.h
+++ b/src/SpaceVecAlg/AdmittanceVec.h
@@ -43,6 +43,13 @@ public:
 	friend class PTransform<T>;
 
 public:
+	/// Zero admittance vector
+	static AdmittanceVec<T> Zero()
+	{
+		return AdmittanceVec<T>(vector3_t::Zero(), vector3_t::Zero());
+	}
+
+public:
 	AdmittanceVec():
 		angular_(),
 		linear_()

--- a/src/SpaceVecAlg/AdmittanceVec.h
+++ b/src/SpaceVecAlg/AdmittanceVec.h
@@ -187,6 +187,12 @@ inline MotionVec<T> operator*(const AdmittanceVec<T>& av, const ForceVec<T>& fv)
 }
 
 template<typename T>
+inline MotionVec<T> operator*(const ForceVec<T>& fv, const AdmittanceVec<T>& av)
+{
+	return av * fv;
+}
+
+template<typename T>
 inline std::ostream& operator<<(std::ostream& out, const AdmittanceVec<T>& av)
 {
 	out << av.vector().transpose();

--- a/src/SpaceVecAlg/AdmittanceVec.h
+++ b/src/SpaceVecAlg/AdmittanceVec.h
@@ -50,6 +50,7 @@ public:
 	}
 
 public:
+	/** Empty constructor */
 	AdmittanceVec():
 		angular_(),
 		linear_()

--- a/src/SpaceVecAlg/AdmittanceVec.h
+++ b/src/SpaceVecAlg/AdmittanceVec.h
@@ -56,7 +56,7 @@ public:
 		linear_()
 	{}
 
-	/**
+	/** Define admittance from 6D vector.
 		* @param vec Admittance vector with angular motion in head
 		* and linear motion in tail.
 		*/
@@ -65,7 +65,7 @@ public:
 		linear_(vec.template tail<3>())
 	{}
 
-	/**
+	/** Define admittance from angular and linear components.
 		* @param angular Angular admittance.
 		* @param linear Linear admittance.
 		*/

--- a/src/SpaceVecAlg/AdmittanceVec.h
+++ b/src/SpaceVecAlg/AdmittanceVec.h
@@ -66,6 +66,15 @@ public:
 		linear_(linear)
 	{}
 
+	/** Homogeneous admittance constructor.
+		* @param angular Angular admittance.
+		* @param linear Linear admittance.
+		*/
+	AdmittanceVec(T angular, T linear):
+		angular_(angular, angular, angular),
+		linear_(linear, linear, linear)
+	{}
+
 	// Accessor
 	/// @return Angular admittance
 	const vector3_t& angular() const

--- a/src/SpaceVecAlg/AdmittanceVec.h
+++ b/src/SpaceVecAlg/AdmittanceVec.h
@@ -24,14 +24,14 @@ using namespace Eigen;
 
 /**
 	* Admittance Vector.
-    * Mechanical admittance is a measure of how much a structure moves
-    * in response to a given force:
-    *
-    *     v = A * F 
-    *
-    * where F is the exerted force, A the admittance and v the resulting output
-    * velocity. Admittance is the reciprocal of mechanical impedance; see
-    * <https://en.wikipedia.org/wiki/Mechanical_impedance>.
+	* Mechanical admittance is a measure of how much a structure moves
+	* in response to a given force:
+	*
+	*     v = A * F
+	*
+	* where F is the exerted force, A the admittance and v the resulting output
+	* velocity. Admittance is the reciprocal of mechanical impedance; see
+	* <https://en.wikipedia.org/wiki/Mechanical_impedance>.
 	*/
 template<typename T>
 class AdmittanceVec

--- a/src/SpaceVecAlg/AdmittanceVec.h
+++ b/src/SpaceVecAlg/AdmittanceVec.h
@@ -40,8 +40,6 @@ public:
 	typedef Vector3<T> vector3_t;
 	typedef Vector6<T> vector6_t;
 
-	friend class PTransform<T>;
-
 public:
 	/// Zero admittance vector
 	static AdmittanceVec<T> Zero()

--- a/src/SpaceVecAlg/AdmittanceVec.h
+++ b/src/SpaceVecAlg/AdmittanceVec.h
@@ -152,7 +152,7 @@ public:
 
 	bool operator!=(const AdmittanceVec<T>& av) const
 	{
-		return (angular_ != av.angular_) || (linear_ != av.linear_);
+		return !(*this == av);
 	}
 
 private:

--- a/src/SpaceVecAlg/AdmittanceVec.h
+++ b/src/SpaceVecAlg/AdmittanceVec.h
@@ -1,0 +1,165 @@
+// Copyright 2012-2018 CNRS-UM LIRMM, CNRS-AIST JRL
+//
+// This file is part of SpaceVecAlg.
+//
+// SpaceVecAlg is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SpaceVecAlg is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have receaved a copy of the GNU Lesser General Public License
+// along with SpaceVecAlg.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+namespace sva
+{
+
+using namespace Eigen;
+
+/**
+	* Admittance Vector.
+    * Mechanical admittance is a measure of how much a structure moves
+    * in response to a given force:
+    *
+    *     v = A * F 
+    *
+    * where F is the exerted force, A the admittance and v the resulting output
+    * velocity. Admittance is the reciprocal of mechanical impedance; see
+    * <https://en.wikipedia.org/wiki/Mechanical_impedance>.
+	*/
+template<typename T>
+class AdmittanceVec
+{
+public:
+	typedef Vector3<T> vector3_t;
+	typedef Vector6<T> vector6_t;
+
+	friend class PTransform<T>;
+
+public:
+	AdmittanceVec():
+		angular_(),
+		linear_()
+	{}
+
+	/**
+		* @param vec Admittance vector with angular motion in head
+		* and linear motion in tail.
+		*/
+	AdmittanceVec(const vector6_t& vec):
+		angular_(vec.template head<3>()),
+		linear_(vec.template tail<3>())
+	{}
+
+	/**
+		* @param angular Angular admittance.
+		* @param linear Linear admittance.
+		*/
+	AdmittanceVec(const vector3_t& angular, const vector3_t& linear):
+		angular_(angular),
+		linear_(linear)
+	{}
+
+	// Accessor
+	/// @return Angular admittance
+	const vector3_t& angular() const
+	{
+		return angular_;
+	}
+
+	/// @return Angular admittance
+	vector3_t& angular()
+	{
+		return angular_;
+	}
+
+	/// @return Linear admittance
+	const vector3_t& linear() const
+	{
+		return linear_;
+	}
+
+	/// @return Linear admittance
+	vector3_t& linear()
+	{
+		return linear_;
+	}
+
+	/// @return Non-compact admittance vector.
+	vector6_t vector() const
+	{
+		return ((vector6_t() << angular_, linear_).finished());
+	}
+
+	template<typename T2>
+	AdmittanceVec<T2> cast() const
+	{
+		return AdmittanceVec<T2>(angular_.template cast<T2>(), linear_.template cast<T2>());
+	}
+
+	// Operators
+	AdmittanceVec<T> operator+(const AdmittanceVec<T>& av) const
+	{
+		return AdmittanceVec<T>(angular_ + av.angular_, linear_ + av.linear_);
+	}
+
+	AdmittanceVec<T>& operator+=(const AdmittanceVec<T>& av)
+	{
+		angular_ += av.angular_;
+		linear_ += av.linear_;
+		return *this;
+	}
+
+	template<typename T2>
+	AdmittanceVec<T> operator*(T2 scalar) const
+	{
+		return AdmittanceVec<T>(scalar*angular_, scalar*linear_);
+	}
+
+	template<typename T2>
+	AdmittanceVec<T> operator/(T2 scalar) const
+	{
+		return AdmittanceVec<T>(angular_/scalar, linear_/scalar);
+	}
+
+	bool operator==(const AdmittanceVec<T>& av) const
+	{
+		return (angular_ == av.angular_) && (linear_ == av.linear_);
+	}
+
+	bool operator!=(const AdmittanceVec<T>& av) const
+	{
+		return (angular_ != av.angular_) || (linear_ != av.linear_);
+	}
+
+private:
+	vector3_t angular_;
+	vector3_t linear_;
+};
+
+template<typename T, typename T2>
+inline AdmittanceVec<T> operator*(T2 scalar, const AdmittanceVec<T>& av)
+{
+	return av*scalar;
+}
+
+template<typename T>
+inline MotionVec<T> operator*(const AdmittanceVec<T>& av, const ForceVec<T>& fv)
+{
+	return MotionVec<T>(av.angular().cwiseProduct(fv.couple()), av.linear().cwiseProduct(fv.force()));
+}
+
+template<typename T>
+inline std::ostream& operator<<(std::ostream& out, const AdmittanceVec<T>& av)
+{
+	out << av.vector().transpose();
+	return out;
+}
+
+} // namespace sva

--- a/src/SpaceVecAlg/AdmittanceVec.h
+++ b/src/SpaceVecAlg/AdmittanceVec.h
@@ -138,9 +138,25 @@ public:
 	}
 
 	template<typename T2>
+	AdmittanceVec<T> & operator*=(T2 scalar)
+	{
+		angular_ *= scalar;
+		linear_ *= scalar;
+		return *this;
+	}
+
+	template<typename T2>
 	AdmittanceVec<T> operator/(T2 scalar) const
 	{
 		return AdmittanceVec<T>(angular_/scalar, linear_/scalar);
+	}
+
+	template<typename T2>
+	AdmittanceVec<T> & operator/=(T2 scalar)
+	{
+		angular_ /= scalar;
+		linear_ /= scalar;
+		return *this;
 	}
 
 	bool operator==(const AdmittanceVec<T>& av) const

--- a/src/SpaceVecAlg/ForceVec.h
+++ b/src/SpaceVecAlg/ForceVec.h
@@ -36,6 +36,13 @@ public:
 	friend class PTransform<T>;
 
 public:
+	/// Zero force vector
+	static ForceVec<T> Zero()
+	{
+		return ForceVec<T>(vector3_t::Zero(), vector3_t::Zero());
+	}
+
+public:
 	ForceVec():
 		couple_(),
 		force_()

--- a/src/SpaceVecAlg/ForceVec.h
+++ b/src/SpaceVecAlg/ForceVec.h
@@ -58,12 +58,30 @@ public:
 
 	// Accessor
 	/// @return Couple
+    /// 
+    /// @note The term "couple" is used in SpaceVecAlg with the general meaning
+    /// of "moment" of a force vector. It should not to be confused with the
+    /// more precise meaning of a "pure moment" that is also found in mechanics
+    /// <https://en.wikipedia.org/wiki/Couple_(mechanics)>.
+    ///
+    /// @sa moment()
 	vector3_t& couple()
 	{
 		return couple_;
 	}
 
 	const vector3_t& couple() const
+	{
+		return couple_;
+	}
+
+	/// @return Moment
+	vector3_t& moment()
+	{
+		return couple_;
+	}
+
+	const vector3_t& moment() const
 	{
 		return couple_;
 	}

--- a/src/SpaceVecAlg/ForceVec.h
+++ b/src/SpaceVecAlg/ForceVec.h
@@ -58,13 +58,13 @@ public:
 
 	// Accessor
 	/// @return Couple
-    /// 
-    /// @note The term "couple" is used in SpaceVecAlg with the general meaning
-    /// of "moment" of a force vector. It should not to be confused with the
-    /// more precise meaning of a "pure moment" that is also found in mechanics
-    /// <https://en.wikipedia.org/wiki/Couple_(mechanics)>.
-    ///
-    /// @sa moment()
+	///
+	/// @note The term "couple" is used in SpaceVecAlg with the general meaning
+	/// of "moment" of a force vector. It should not to be confused with the
+	/// more precise meaning of a "pure moment" that is also found in mechanics
+	/// <https://en.wikipedia.org/wiki/Couple_(mechanics)>.
+	///
+	/// @sa moment()
 	vector3_t& couple()
 	{
 		return couple_;

--- a/src/SpaceVecAlg/ImpedanceVec.h
+++ b/src/SpaceVecAlg/ImpedanceVec.h
@@ -137,9 +137,25 @@ public:
 	}
 
 	template<typename T2>
+	ImpedanceVec<T> & operator*=(T2 scalar)
+	{
+		angular_ *= scalar;
+		linear_ *= scalar;
+		return *this;
+	}
+
+	template<typename T2>
 	ImpedanceVec<T> operator/(T2 scalar) const
 	{
 		return ImpedanceVec<T>(angular_/scalar, linear_/scalar);
+	}
+
+	template<typename T2>
+	ImpedanceVec<T> & operator/=(T2 scalar)
+	{
+		angular_ /= scalar;
+		linear_ /= scalar;
+		return *this;
 	}
 
 	bool operator==(const ImpedanceVec<T>& iv) const

--- a/src/SpaceVecAlg/ImpedanceVec.h
+++ b/src/SpaceVecAlg/ImpedanceVec.h
@@ -65,6 +65,15 @@ public:
 		linear_(linear)
 	{}
 
+	/** Homogeneous impedance constructor.
+		* @param angular Angular impedance.
+		* @param linear Linear impedance.
+		*/
+	ImpedanceVec(T angular, T linear):
+		angular_(angular, angular, angular),
+		linear_(linear, linear, linear)
+	{}
+
 	// Accessor
 	/// @return Angular impedance
 	const vector3_t& angular() const

--- a/src/SpaceVecAlg/ImpedanceVec.h
+++ b/src/SpaceVecAlg/ImpedanceVec.h
@@ -151,7 +151,7 @@ public:
 
 	bool operator!=(const ImpedanceVec<T>& iv) const
 	{
-		return (angular_ != iv.angular_) || (linear_ != iv.linear_);
+		return !(*this == iv);
 	}
 
 private:

--- a/src/SpaceVecAlg/ImpedanceVec.h
+++ b/src/SpaceVecAlg/ImpedanceVec.h
@@ -55,7 +55,7 @@ public:
 		linear_()
 	{}
 
-	/**
+	/** Define impedance from 6D vector.
 		* @param vec Impedance vector with angular motion in head
 		* and linear motion in tail.
 		*/
@@ -64,7 +64,7 @@ public:
 		linear_(vec.template tail<3>())
 	{}
 
-	/**
+	/** Define impedance from angular and linear components.
 		* @param angular Angular impedance.
 		* @param linear Linear impedance.
 		*/

--- a/src/SpaceVecAlg/ImpedanceVec.h
+++ b/src/SpaceVecAlg/ImpedanceVec.h
@@ -42,6 +42,13 @@ public:
 	friend class PTransform<T>;
 
 public:
+	/// Zero impedance vector
+	static ImpedanceVec<T> Zero()
+	{
+		return ImpedanceVec<T>(vector3_t::Zero(), vector3_t::Zero());
+	}
+
+public:
 	ImpedanceVec():
 		angular_(),
 		linear_()

--- a/src/SpaceVecAlg/ImpedanceVec.h
+++ b/src/SpaceVecAlg/ImpedanceVec.h
@@ -1,0 +1,164 @@
+// Copyright 2012-2018 CNRS-UM LIRMM, CNRS-AIST JRL
+//
+// This file is part of SpaceVecAlg.
+//
+// SpaceVecAlg is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SpaceVecAlg is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with SpaceVecAlg.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+namespace sva
+{
+
+using namespace Eigen;
+
+/**
+	* Impedance Vector.
+    * Mechanical impedance is a measure of how much a structure resists
+    * motion when subjected to a given force:
+    *
+    *     F = Z * v 
+    *
+    * where F is the exerted force, Z the impedance and v the resulting output
+    * velocity. See <https://en.wikipedia.org/wiki/Mechanical_impedance>.
+	*/
+template<typename T>
+class ImpedanceVec
+{
+public:
+	typedef Vector3<T> vector3_t;
+	typedef Vector6<T> vector6_t;
+
+	friend class PTransform<T>;
+
+public:
+	ImpedanceVec():
+		angular_(),
+		linear_()
+	{}
+
+	/**
+		* @param vec Impedance vector with angular motion in head
+		* and linear motion in tail.
+		*/
+	ImpedanceVec(const vector6_t& vec):
+		angular_(vec.template head<3>()),
+		linear_(vec.template tail<3>())
+	{}
+
+	/**
+		* @param angular Angular impedance.
+		* @param linear Linear impedance.
+		*/
+	ImpedanceVec(const vector3_t& angular, const vector3_t& linear):
+		angular_(angular),
+		linear_(linear)
+	{}
+
+	// Accessor
+	/// @return Angular impedance
+	const vector3_t& angular() const
+	{
+		return angular_;
+	}
+
+	/// @return Angular impedance
+	vector3_t& angular()
+	{
+		return angular_;
+	}
+
+	/// @return Linear impedance
+	const vector3_t& linear() const
+	{
+		return linear_;
+	}
+
+	/// @return Linear impedance
+	vector3_t& linear()
+	{
+		return linear_;
+	}
+
+	/// @return Non compact impedance vector.
+	vector6_t vector() const
+	{
+		return ((vector6_t() << angular_, linear_).finished());
+	}
+
+	template<typename T2>
+	ImpedanceVec<T2> cast() const
+	{
+		return ImpedanceVec<T2>(angular_.template cast<T2>(), linear_.template cast<T2>());
+	}
+
+	// Operators
+	ImpedanceVec<T> operator+(const ImpedanceVec<T>& iv) const
+	{
+		return ImpedanceVec<T>(angular_ + iv.angular_, linear_ + iv.linear_);
+	}
+
+	ImpedanceVec<T>& operator+=(const ImpedanceVec<T>& iv)
+	{
+		angular_ += iv.angular_;
+		linear_ += iv.linear_;
+		return *this;
+	}
+
+	template<typename T2>
+	ImpedanceVec<T> operator*(T2 scalar) const
+	{
+		return ImpedanceVec<T>(scalar*angular_, scalar*linear_);
+	}
+
+	template<typename T2>
+	ImpedanceVec<T> operator/(T2 scalar) const
+	{
+		return ImpedanceVec<T>(angular_/scalar, linear_/scalar);
+	}
+
+	bool operator==(const ImpedanceVec<T>& iv) const
+	{
+		return (angular_ == iv.angular_) && (linear_ == iv.linear_);
+	}
+
+	bool operator!=(const ImpedanceVec<T>& iv) const
+	{
+		return (angular_ != iv.angular_) || (linear_ != iv.linear_);
+	}
+
+private:
+	vector3_t angular_;
+	vector3_t linear_;
+};
+
+template<typename T, typename T2>
+inline ImpedanceVec<T> operator*(T2 scalar, const ImpedanceVec<T>& iv)
+{
+	return iv*scalar;
+}
+
+template<typename T>
+inline ForceVec<T> operator*(const ImpedanceVec<T>& iv, const MotionVec<T>& mv)
+{
+	return ForceVec<T>(iv.angular().cwiseProduct(mv.angular()), iv.linear().cwiseProduct(mv.linear()));
+}
+
+template<typename T>
+inline std::ostream& operator<<(std::ostream& out, const ImpedanceVec<T>& iv)
+{
+	out << iv.vector().transpose();
+	return out;
+}
+
+} // namespace sva

--- a/src/SpaceVecAlg/ImpedanceVec.h
+++ b/src/SpaceVecAlg/ImpedanceVec.h
@@ -49,6 +49,7 @@ public:
 	}
 
 public:
+	/** Empty constructor */
 	ImpedanceVec():
 		angular_(),
 		linear_()

--- a/src/SpaceVecAlg/ImpedanceVec.h
+++ b/src/SpaceVecAlg/ImpedanceVec.h
@@ -186,6 +186,12 @@ inline ForceVec<T> operator*(const ImpedanceVec<T>& iv, const MotionVec<T>& mv)
 }
 
 template<typename T>
+inline ForceVec<T> operator*(const MotionVec<T> & mv, const ImpedanceVec<T> & iv)
+{
+	return iv * mv;
+}
+
+template<typename T>
 inline std::ostream& operator<<(std::ostream& out, const ImpedanceVec<T>& iv)
 {
 	out << iv.vector().transpose();

--- a/src/SpaceVecAlg/ImpedanceVec.h
+++ b/src/SpaceVecAlg/ImpedanceVec.h
@@ -24,13 +24,13 @@ using namespace Eigen;
 
 /**
 	* Impedance Vector.
-    * Mechanical impedance is a measure of how much a structure resists
-    * motion when subjected to a given force:
-    *
-    *     F = Z * v 
-    *
-    * where F is the exerted force, Z the impedance and v the resulting output
-    * velocity. See <https://en.wikipedia.org/wiki/Mechanical_impedance>.
+	* Mechanical impedance is a measure of how much a structure resists
+	* motion when subjected to a given force:
+	*
+	*     F = Z * v
+	*
+	* where F is the exerted force, Z the impedance and v the resulting output
+	* velocity. See <https://en.wikipedia.org/wiki/Mechanical_impedance>.
 	*/
 template<typename T>
 class ImpedanceVec

--- a/src/SpaceVecAlg/ImpedanceVec.h
+++ b/src/SpaceVecAlg/ImpedanceVec.h
@@ -39,8 +39,6 @@ public:
 	typedef Vector3<T> vector3_t;
 	typedef Vector6<T> vector6_t;
 
-	friend class PTransform<T>;
-
 public:
 	/// Zero impedance vector
 	static ImpedanceVec<T> Zero()

--- a/src/SpaceVecAlg/MotionVec.h
+++ b/src/SpaceVecAlg/MotionVec.h
@@ -36,6 +36,13 @@ public:
 	friend class PTransform<T>;
 
 public:
+	/// Zero motion vector
+	static MotionVec<T> Zero()
+	{
+		return MotionVec<T>(vector3_t::Zero(), vector3_t::Zero());
+	}
+
+public:
 	MotionVec():
 		angular_(),
 		linear_()

--- a/src/SpaceVecAlg/SpaceVecAlg
+++ b/src/SpaceVecAlg/SpaceVecAlg
@@ -42,6 +42,8 @@ namespace sva
 
 #include "MotionVec.h"
 #include "ForceVec.h"
+#include "ImpedanceVec.h"
+#include "AdmittanceVec.h"
 #include "RBInertia.h"
 #include "ABInertia.h"
 #include "PTransform.h"
@@ -52,6 +54,8 @@ namespace sva
 {
 	typedef MotionVec<double> MotionVecd;
 	typedef ForceVec<double> ForceVecd;
+	typedef ImpedanceVec<double> ImpedanceVecd;
+	typedef AdmittanceVec<double> AdmittanceVecd;
 	typedef RBInertia<double> RBInertiad;
 	typedef ABInertia<double> ABInertiad;
 	typedef PTransform<double> PTransformd;

--- a/tests/VectorTest.cpp
+++ b/tests/VectorTest.cpp
@@ -281,13 +281,13 @@ BOOST_AUTO_TEST_CASE(ImpedanceVecdTest)
 	v = Vector3d::Random();
 	sva::MotionVecd mv(w, v);
 
-    // operator *
-    sva::ForceVecd fv = vec * mv;
+	// operator *
+	sva::ForceVecd fv = vec * mv;
 	BOOST_CHECK_EQUAL(fv.force(), vec.linear().cwiseProduct(mv.linear()));
 	BOOST_CHECK_EQUAL(fv.couple(), vec.angular().cwiseProduct(mv.angular()));
-    //
-    // homogeneous constructor
-    sva::ImpedanceVecd hiv(11., 42.);
+
+	// homogeneous constructor
+	sva::ImpedanceVecd hiv(11., 42.);
 	BOOST_CHECK_EQUAL(hiv.angular(), Eigen::Vector3d(11., 11., 11.));
 	BOOST_CHECK_EQUAL(hiv.linear(), Eigen::Vector3d(42., 42., 42.));
 }
@@ -346,13 +346,13 @@ BOOST_AUTO_TEST_CASE(AdmittanceVecdTest)
 	Vector3d f = Vector3d::Random();
 	sva::ForceVecd fv(n, f);
 
-    // operator *
-    sva::MotionVecd mv = vec * fv;
+	// operator *
+	sva::MotionVecd mv = vec * fv;
 	BOOST_CHECK_EQUAL(mv.linear(), vec.linear().cwiseProduct(fv.force()));
 	BOOST_CHECK_EQUAL(mv.angular(), vec.angular().cwiseProduct(fv.couple()));
 
-    // homogeneous constructor
-    sva::AdmittanceVecd hav(11., 42.);
+	// homogeneous constructor
+	sva::AdmittanceVecd hav(11., 42.);
 	BOOST_CHECK_EQUAL(hav.angular(), Eigen::Vector3d(11., 11., 11.));
 	BOOST_CHECK_EQUAL(hav.linear(), Eigen::Vector3d(42., 42., 42.));
 }

--- a/tests/VectorTest.cpp
+++ b/tests/VectorTest.cpp
@@ -227,3 +227,123 @@ BOOST_AUTO_TEST_CASE(MotionVecdLeftOperatorsTest)
 	BOOST_CHECK_EQUAL(crossFVecRes.col(0), crossFVecRes.col(1));
 }
 
+BOOST_AUTO_TEST_CASE(ImpedanceVecdTest)
+{
+	using namespace Eigen;
+	Vector3d w, v;
+	Vector6d z;
+	w = Vector3d::Random();
+	v = Vector3d::Random();
+
+	sva::ImpedanceVecd vec(w, v);
+	z = vec.vector();
+
+	// angular
+	BOOST_CHECK_EQUAL(w, vec.angular());
+
+	// linear
+	BOOST_CHECK_EQUAL(v, vec.linear());
+
+	// vector
+	BOOST_CHECK_EQUAL(z, (Vector6d() << w, v).finished());
+
+	// alpha*M
+	BOOST_CHECK_EQUAL((5.*vec).vector(), (5.*z).eval());
+
+	// M*alpha
+	BOOST_CHECK_EQUAL((vec*5.).vector(), (5.*z).eval());
+
+	// M/alpha
+	BOOST_CHECK_EQUAL((vec/5.).vector(), (z/5.).eval());
+
+	Vector3d w2, v2;
+	w2 = Vector3d::Random();
+	v2 = Vector3d::Random();
+	Vector6d z2;
+	sva::ImpedanceVecd vec2(w2, v2);
+	z2 = vec2.vector();
+
+	// M + M
+	BOOST_CHECK_EQUAL((vec + vec2).vector(), (z + z2).eval());
+
+	// M += M
+	sva::ImpedanceVecd vec_pluseq(vec);
+	vec_pluseq += vec2;
+	BOOST_CHECK_EQUAL(vec_pluseq, vec + vec2);
+
+	// ==
+	BOOST_CHECK_EQUAL(vec, vec);
+
+	// !=
+	BOOST_CHECK(!(vec != vec));
+
+	w = Vector3d::Random();
+	v = Vector3d::Random();
+	sva::MotionVecd mv(w, v);
+
+    // operator *
+    sva::ForceVecd fv = vec * mv;
+	BOOST_CHECK_EQUAL(fv.force(), vec.linear().cwiseProduct(mv.linear()));
+	BOOST_CHECK_EQUAL(fv.couple(), vec.angular().cwiseProduct(mv.angular()));
+}
+
+BOOST_AUTO_TEST_CASE(AdmittanceVecdTest)
+{
+	using namespace Eigen;
+	Vector3d w, v;
+	Vector6d a;
+	w = Vector3d::Random();
+	v = Vector3d::Random();
+
+	sva::AdmittanceVecd vec(w, v);
+	a = vec.vector();
+
+	// angular
+	BOOST_CHECK_EQUAL(w, vec.angular());
+
+	// linear
+	BOOST_CHECK_EQUAL(v, vec.linear());
+
+	// vector
+	BOOST_CHECK_EQUAL(a, (Vector6d() << w, v).finished());
+
+	// alpha*M
+	BOOST_CHECK_EQUAL((5.*vec).vector(), (5.*a).eval());
+
+	// M*alpha
+	BOOST_CHECK_EQUAL((vec*5.).vector(), (5.*a).eval());
+
+	// M/alpha
+	BOOST_CHECK_EQUAL((vec/5.).vector(), (a/5.).eval());
+
+	Vector3d w2, v2;
+	w2 = Vector3d::Random();
+	v2 = Vector3d::Random();
+	Vector6d a2;
+	sva::AdmittanceVecd vec2(w2, v2);
+	a2 = vec2.vector();
+
+	// M + M
+	BOOST_CHECK_EQUAL((vec + vec2).vector(), (a + a2).eval());
+
+	// M += M
+	sva::AdmittanceVecd vec_pluseq(vec);
+	vec_pluseq += vec2;
+	BOOST_CHECK_EQUAL(vec_pluseq, vec + vec2);
+
+	// ==
+	BOOST_CHECK_EQUAL(vec, vec);
+
+	// !=
+	BOOST_CHECK(!(vec != vec));
+
+	Vector3d n = Vector3d::Random();
+	Vector3d f = Vector3d::Random();
+	sva::ForceVecd fv(n, f);
+
+    // operator *
+    sva::MotionVecd mv = vec * fv;
+	BOOST_CHECK_EQUAL(mv.linear(), vec.linear().cwiseProduct(fv.force()));
+	BOOST_CHECK_EQUAL(mv.angular(), vec.angular().cwiseProduct(fv.couple()));
+}
+

--- a/tests/VectorTest.cpp
+++ b/tests/VectorTest.cpp
@@ -304,6 +304,9 @@ BOOST_AUTO_TEST_CASE(ImpedanceVecdTest)
 	BOOST_CHECK_EQUAL(fv.force(), vec.linear().cwiseProduct(mv.linear()));
 	BOOST_CHECK_EQUAL(fv.couple(), vec.angular().cwiseProduct(mv.angular()));
 
+	sva::ForceVecd fv2 = mv * vec;
+	BOOST_CHECK_EQUAL(fv, fv2);
+
 	// homogeneous constructor
 	sva::ImpedanceVecd hiv(11., 42.);
 	BOOST_CHECK_EQUAL(hiv.angular(), Eigen::Vector3d(11., 11., 11.));
@@ -383,6 +386,9 @@ BOOST_AUTO_TEST_CASE(AdmittanceVecdTest)
 	sva::MotionVecd mv = vec * fv;
 	BOOST_CHECK_EQUAL(mv.linear(), vec.linear().cwiseProduct(fv.force()));
 	BOOST_CHECK_EQUAL(mv.angular(), vec.angular().cwiseProduct(fv.couple()));
+
+	sva::MotionVecd mv2 = fv * vec;
+	BOOST_CHECK_EQUAL(mv, mv2);
 
 	// homogeneous constructor
 	sva::AdmittanceVecd hav(11., 42.);

--- a/tests/VectorTest.cpp
+++ b/tests/VectorTest.cpp
@@ -262,6 +262,24 @@ BOOST_AUTO_TEST_CASE(ImpedanceVecdTest)
 	// M/alpha
 	BOOST_CHECK_EQUAL((vec/5.).vector(), (z/5.).eval());
 
+	// ==
+	BOOST_CHECK_EQUAL(vec, vec);
+
+	// !=
+	BOOST_CHECK(!(vec != vec));
+
+	// Copy
+	sva::ImpedanceVecd vec_tmp = vec;
+	BOOST_CHECK_EQUAL(vec, vec_tmp);
+
+	// *= alpha
+	vec_tmp *= 5.;
+	BOOST_CHECK_EQUAL(vec_tmp.vector(), (5.*z).eval());
+
+	// /= alpha
+	vec_tmp /= 5.;
+	BOOST_CHECK(vec_tmp.vector().isApprox(z));
+
 	Vector3d w2, v2;
 	w2 = Vector3d::Random();
 	v2 = Vector3d::Random();
@@ -276,12 +294,6 @@ BOOST_AUTO_TEST_CASE(ImpedanceVecdTest)
 	sva::ImpedanceVecd vec_pluseq(vec);
 	vec_pluseq += vec2;
 	BOOST_CHECK_EQUAL(vec_pluseq, vec + vec2);
-
-	// ==
-	BOOST_CHECK_EQUAL(vec, vec);
-
-	// !=
-	BOOST_CHECK(!(vec != vec));
 
 	w = Vector3d::Random();
 	v = Vector3d::Random();
@@ -330,6 +342,24 @@ BOOST_AUTO_TEST_CASE(AdmittanceVecdTest)
 	// M/alpha
 	BOOST_CHECK_EQUAL((vec/5.).vector(), (a/5.).eval());
 
+	// ==
+	BOOST_CHECK_EQUAL(vec, vec);
+
+	// !=
+	BOOST_CHECK(!(vec != vec));
+
+	// Copy
+	sva::AdmittanceVecd vec_tmp = vec;
+	BOOST_CHECK_EQUAL(vec, vec_tmp);
+
+	// *= alpha
+	vec_tmp *= 5.;
+	BOOST_CHECK_EQUAL(vec_tmp.vector(), (5.*a).eval());
+
+	// /= alpha
+	vec_tmp /= 5.;
+	BOOST_CHECK(vec_tmp.vector().isApprox(a));
+
 	Vector3d w2, v2;
 	w2 = Vector3d::Random();
 	v2 = Vector3d::Random();
@@ -344,12 +374,6 @@ BOOST_AUTO_TEST_CASE(AdmittanceVecdTest)
 	sva::AdmittanceVecd vec_pluseq(vec);
 	vec_pluseq += vec2;
 	BOOST_CHECK_EQUAL(vec_pluseq, vec + vec2);
-
-	// ==
-	BOOST_CHECK_EQUAL(vec, vec);
-
-	// !=
-	BOOST_CHECK(!(vec != vec));
 
 	Vector3d n = Vector3d::Random();
 	Vector3d f = Vector3d::Random();

--- a/tests/VectorTest.cpp
+++ b/tests/VectorTest.cpp
@@ -96,6 +96,9 @@ BOOST_AUTO_TEST_CASE(MotionVecdTest)
 	// !=
 	BOOST_CHECK(vec != (-vec));
 	BOOST_CHECK(!(vec != vec));
+
+	// zero
+	BOOST_CHECK_EQUAL(sva::MotionVecd::Zero().vector(), Eigen::Vector6d::Zero());
 }
 
 BOOST_AUTO_TEST_CASE(ForceVecdTest)
@@ -160,6 +163,9 @@ BOOST_AUTO_TEST_CASE(ForceVecdTest)
 	// !=
 	BOOST_CHECK(vec != (-vec));
 	BOOST_CHECK(!(vec != vec));
+
+	// zero
+	BOOST_CHECK_EQUAL(sva::ForceVecd::Zero().vector(), Eigen::Vector6d::Zero());
 }
 
 BOOST_AUTO_TEST_CASE(MotionVecdLeftOperatorsTest)
@@ -290,6 +296,9 @@ BOOST_AUTO_TEST_CASE(ImpedanceVecdTest)
 	sva::ImpedanceVecd hiv(11., 42.);
 	BOOST_CHECK_EQUAL(hiv.angular(), Eigen::Vector3d(11., 11., 11.));
 	BOOST_CHECK_EQUAL(hiv.linear(), Eigen::Vector3d(42., 42., 42.));
+
+	// zero
+	BOOST_CHECK_EQUAL(sva::ImpedanceVecd::Zero().vector(), Eigen::Vector6d::Zero());
 }
 
 BOOST_AUTO_TEST_CASE(AdmittanceVecdTest)
@@ -355,5 +364,7 @@ BOOST_AUTO_TEST_CASE(AdmittanceVecdTest)
 	sva::AdmittanceVecd hav(11., 42.);
 	BOOST_CHECK_EQUAL(hav.angular(), Eigen::Vector3d(11., 11., 11.));
 	BOOST_CHECK_EQUAL(hav.linear(), Eigen::Vector3d(42., 42., 42.));
-}
 
+	// zero
+	BOOST_CHECK_EQUAL(sva::AdmittanceVecd::Zero().vector(), Eigen::Vector6d::Zero());
+}

--- a/tests/VectorTest.cpp
+++ b/tests/VectorTest.cpp
@@ -285,6 +285,11 @@ BOOST_AUTO_TEST_CASE(ImpedanceVecdTest)
     sva::ForceVecd fv = vec * mv;
 	BOOST_CHECK_EQUAL(fv.force(), vec.linear().cwiseProduct(mv.linear()));
 	BOOST_CHECK_EQUAL(fv.couple(), vec.angular().cwiseProduct(mv.angular()));
+    //
+    // homogeneous constructor
+    sva::ImpedanceVecd hiv(11., 42.);
+	BOOST_CHECK_EQUAL(hiv.angular(), Eigen::Vector3d(11., 11., 11.));
+	BOOST_CHECK_EQUAL(hiv.linear(), Eigen::Vector3d(42., 42., 42.));
 }
 
 BOOST_AUTO_TEST_CASE(AdmittanceVecdTest)
@@ -345,5 +350,10 @@ BOOST_AUTO_TEST_CASE(AdmittanceVecdTest)
     sva::MotionVecd mv = vec * fv;
 	BOOST_CHECK_EQUAL(mv.linear(), vec.linear().cwiseProduct(fv.force()));
 	BOOST_CHECK_EQUAL(mv.angular(), vec.angular().cwiseProduct(fv.couple()));
+
+    // homogeneous constructor
+    sva::AdmittanceVecd hav(11., 42.);
+	BOOST_CHECK_EQUAL(hav.angular(), Eigen::Vector3d(11., 11., 11.));
+	BOOST_CHECK_EQUAL(hav.linear(), Eigen::Vector3d(42., 42., 42.));
 }
 


### PR DESCRIPTION
This PR adds named types for admittance (motion → force) and impedance (force → motion) quantities. 

It allows one to write such things as:
```c++
sva::ForceVecd F = sva::ImpedanceVecd(10., 5.) * sva::MotionVecd({0., 0., 1.}, {0., 0., 0.});
sva::MotionVecd M = sva::AdmittanceVecd(0., 1.) * sva::ForceVecd({0., 0., 0.}, {5., 5., 0.});
```

Incidentally, it introduces a `moment()` alias to `couple()` in force vectors, along with a note to clarify that "couples" in SVA denote general moments and not [pure moments](https://en.wikipedia.org/wiki/Couple_(mechanics)).