### PR TITLE
Cleaned out unused ``prec`` argument

### DIFF
--- a/binding/python/sva/c_sva.pxd
+++ b/binding/python/sva/c_sva.pxd
@@ -205,11 +205,11 @@ cdef extern from "<SpaceVecAlg/SpaceVecAlg>" namespace "sva":
   c_eigen.Matrix[T,c_eigen.three,c_eigen.three] RotY[T](T)
   c_eigen.Matrix[T,c_eigen.three,c_eigen.three] RotZ[T](T)
 
-  c_eigen.Matrix[T,c_eigen.three,c_eigen.three] rotationError[T](const c_eigen.Matrix[T,c_eigen.three,c_eigen.three]&, const c_eigen.Matrix[T,c_eigen.three,c_eigen.three]&, T)
-  c_eigen.Matrix[T,c_eigen.three,c_eigen.three] rotationVelocity[T](const c_eigen.Matrix[T,c_eigen.three,c_eigen.three]&, T)
+  c_eigen.Matrix[T,c_eigen.three,c_eigen.three] rotationError[T](const c_eigen.Matrix[T,c_eigen.three,c_eigen.three]&, const c_eigen.Matrix[T,c_eigen.three,c_eigen.three]&)
+  c_eigen.Matrix[T,c_eigen.three,c_eigen.three] rotationVelocity[T](const c_eigen.Matrix[T,c_eigen.three,c_eigen.three]&)
 
-  MotionVec[T] transformError[T](const PTransform[T]&, const PTransform[T]&, T)
-  MotionVec[T] transformVelocity[T](const PTransform[T]&, T)
+  MotionVec[T] transformError[T](const PTransform[T]&, const PTransform[T]&)
+  MotionVec[T] transformVelocity[T](const PTransform[T]&)
 
   c_eigen.Matrix[T,c_eigen.three,c_eigen.three] vector3ToCrossMatrix[T](const c_eigen.Matrix[T,c_eigen.three,c_eigen.one]&)
   c_eigen.Matrix[T,c_eigen.six,c_eigen.six] vector6ToCrossMatrix[T](const c_eigen.Matrix[T,c_eigen.six,c_eigen.one]&)

--- a/binding/python/sva/sva.pyx
+++ b/binding/python/sva/sva.pyx
@@ -871,20 +871,18 @@ def RotY(double theta):
 def RotZ(double theta):
   return eigen.Matrix3dFromC(<c_eigen.Matrix3d>(c_sva.RotZ[double](theta)))
 
-def rotationError(eigen.Matrix3d E_a_b, eigen.Matrix3d E_a_c, double prec = 1e-8):
-  return eigen.Vector3dFromC(<c_eigen.Vector3d>(c_sva.rotationError[double](E_a_b.impl, E_a_c.impl, prec)))
+def rotationError(eigen.Matrix3d E_a_b, eigen.Matrix3d E_a_c):
+  return eigen.Vector3dFromC(<c_eigen.Vector3d>(c_sva.rotationError[double](E_a_b.impl, E_a_c.impl)))
 
-def rotationVelocity(eigen.Matrix3d E_a_b, double prec = 1e-8):
-  return eigen.Vector3dFromC(<c_eigen.Vector3d>(c_sva.rotationVelocity[double](E_a_b.impl,
-      prec)))
+def rotationVelocity(eigen.Matrix3d E_a_b):
+  return eigen.Vector3dFromC(<c_eigen.Vector3d>(c_sva.rotationVelocity[double](E_a_b.impl)))
 
-def transformError(PTransformd X_a_b, PTransformd X_a_c, double prec = 1e-8):
+def transformError(PTransformd X_a_b, PTransformd X_a_c):
   return MotionVecdFromC(c_sva.transformError[double](deref(X_a_b.impl),
-      deref(X_a_c.impl),
-      prec))
+      deref(X_a_c.impl)))
 
-def transformVelocity(PTransformd X_a_b, double prec = 1e-8):
-  return MotionVecdFromC(c_sva.transformVelocity[double](deref(X_a_b.impl), prec))
+def transformVelocity(PTransformd X_a_b):
+  return MotionVecdFromC(c_sva.transformVelocity[double](deref(X_a_b.impl)))
 
 def vector3ToCrossMatrix(eigen.Vector3d v):
   return eigen.Matrix3dFromC(<c_eigen.Matrix3d>(c_sva.vector3ToCrossMatrix[double](v.impl)))

--- a/binding/python/tests/test_sva_ptransform.py
+++ b/binding/python/tests/test_sva_ptransform.py
@@ -195,16 +195,16 @@ class TestTransformError(unittest.TestCase):
     X_a_b = sva.PTransformd(eigen.Quaterniond(eigen.Vector4d.Random()).normalized(), eigen.Vector3d.Random())
     X_a_c = sva.PTransformd(eigen.Quaterniond(eigen.Vector4d.Random()).normalized(), eigen.Vector3d.Random())
 
-    V_a_b = sva.transformVelocity(X_a_b, 1e-7)
-    V_a_c = sva.transformVelocity(X_a_c, 1e-7)
+    V_a_b = sva.transformVelocity(X_a_b)
+    V_a_c = sva.transformVelocity(X_a_c)
 
     self.assertAlmostEqual((V_a_b.angular() - sva.rotationVelocity(X_a_b.rotation())).norm(), 0, delta = TOL)
     self.assertAlmostEqual((V_a_b.linear() - X_a_b.translation()).norm(), 0, delta = TOL)
     self.assertAlmostEqual((V_a_c.angular() - sva.rotationVelocity(X_a_c.rotation())).norm(), 0, delta = TOL)
     self.assertAlmostEqual((V_a_c.linear() - X_a_c.translation()).norm(), 0, delta = TOL)
 
-    V_b_c_a = sva.transformError(X_a_b, X_a_c, 1e-7)
-    w_b_c_a = sva.rotationError(X_a_b.rotation(), X_a_c.rotation(), 1e-7)
+    V_b_c_a = sva.transformError(X_a_b, X_a_c)
+    w_b_c_a = sva.rotationError(X_a_b.rotation(), X_a_c.rotation())
     v_b_c_a = X_a_c.translation() - X_a_b.translation()
 
     self.assertAlmostEqual((V_b_c_a.angular() - w_b_c_a).norm(), 0, delta = TOL)

--- a/src/SpaceVecAlg/PTransform.h
+++ b/src/SpaceVecAlg/PTransform.h
@@ -51,34 +51,29 @@ Matrix3<T> RotZ(T theta);
 	* This method convert the 3D rotation matrix E_b_c into a rotation vector.
 	* The matrix E_b_c is computed as follow E_a_c = E_b_c*E_a_b.
 	* Then the error is computed with E_b_a*rotationVelocity(E_b_c).
-	* @param prec Deprecated.
 	* @return XYZ rotation in radian.
 	*/
 template<typename T>
-Vector3<T> rotationError(const Matrix3<T>& E_a_b, const Matrix3<T>& E_a_c,
-	double prec=1e-8);
+Vector3<T> rotationError(const Matrix3<T>& E_a_b, const Matrix3<T>& E_a_c);
 
 /**
 	* Compute the 3D rotation vector of the rotation matrix E_a_b in the 'a' frame.
 	* If we integrate this rotation vector for 1 second we must
 	* have the rotation matrix E_a_b.
 	* (see exponential matrix and logarithmic matrix).
-	* @param prec Deprecated.
 	*/
 template<typename T>
-Vector3<T> rotationVelocity(const Matrix3<T>& E_a_b, double prec=1e-8);
+Vector3<T> rotationVelocity(const Matrix3<T>& E_a_b);
 
 /**
 	* Compute the 6D error between two PTransform in the 'a' frame.
 	* This method convert the 6D transformation matrix X_b_c into a motion vector.
 	* The matrix X_b_c is computed as follow X_a_c = X_b_c*X_a_b.
 	* Then the error is computed with PTransform(E_b_a)*transformVelocity(X_b_c).
-	* @param prec Deprecated.
 	* @return XYZ rotation in radian.
 	*/
 template<typename T>
-MotionVec<T> transformError(const PTransform<T>& X_a_b, const PTransform<T>& X_a_c,
-	double prec=1e-8);
+MotionVec<T> transformError(const PTransform<T>& X_a_b, const PTransform<T>& X_a_c);
 
 /**
 	* Compute the motion vector of the matrix X_a_b in the 'a' frame.
@@ -87,10 +82,9 @@ MotionVec<T> transformError(const PTransform<T>& X_a_b, const PTransform<T>& X_a
 	* This function can be see as an implementation of the function XtoV
 	* (see Featherstone appendix) but with the use of logarithmic
 	* matrix to compute the rotational error.
-	* @param prec Deprecated.
 	*/
 template<typename T>
-MotionVec<T> transformVelocity(const PTransform<T>& X_a_b, double prec=1e-8);
+MotionVec<T> transformVelocity(const PTransform<T>& X_a_b);
 
 
 /**
@@ -344,16 +338,15 @@ inline Matrix3<T> RotZ(T theta)
 
 
 template<typename T>
-inline Vector3<T> rotationError(const Matrix3<T>& E_a_b, const Matrix3<T>& E_a_c,
-	double prec)
+inline Vector3<T> rotationError(const Matrix3<T>& E_a_b, const Matrix3<T>& E_a_c)
 {
 	Matrix3<T> E_b_c = E_a_c*E_a_b.transpose();
-	return Vector3<T>(E_a_b.transpose()*rotationVelocity(E_b_c, prec));
+	return Vector3<T>(E_a_b.transpose()*rotationVelocity(E_b_c));
 }
 
 
 template<typename T>
-inline Vector3<T> rotationVelocity(const Matrix3<T>& E_a_b, double /* prec */)
+inline Vector3<T> rotationVelocity(const Matrix3<T>& E_a_b)
 {
 	Vector3<T> w;
 	T acosV = (E_a_b(0,0) + E_a_b(1,1) + E_a_b(2,2) - 1.)*0.5;
@@ -369,18 +362,17 @@ inline Vector3<T> rotationVelocity(const Matrix3<T>& E_a_b, double /* prec */)
 
 
 template<typename T>
-inline MotionVec<T> transformError(const PTransform<T>& X_a_b,
-	const PTransform<T>& X_a_c, double prec)
+inline MotionVec<T> transformError(const PTransform<T>& X_a_b, const PTransform<T>& X_a_c)
 {
 	PTransform<T> X_b_c = X_a_c*X_a_b.inv();
-	return PTransform<T>(Matrix3<T>(X_a_b.rotation().transpose()))*transformVelocity(X_b_c, prec);
+	return PTransform<T>(Matrix3<T>(X_a_b.rotation().transpose()))*transformVelocity(X_b_c);
 }
 
 
 template<typename T>
-inline MotionVec<T> transformVelocity(const PTransform<T>& X_a_b, double prec)
+inline MotionVec<T> transformVelocity(const PTransform<T>& X_a_b)
 {
-	return MotionVec<T>(rotationVelocity(X_a_b.rotation(), prec),
+	return MotionVec<T>(rotationVelocity(X_a_b.rotation()),
 		X_a_b.translation());
 }
 

--- a/tests/PTransformTest.cpp
+++ b/tests/PTransformTest.cpp
@@ -328,16 +328,16 @@ BOOST_AUTO_TEST_CASE(TransformError)
 	PTransformd X_a_b(Quaterniond(Vector4d::Random()).normalized(), Vector3d::Random());
 	PTransformd X_a_c(Quaterniond(Vector4d::Random()).normalized(), Vector3d::Random());
 
-	MotionVecd V_a_b = transformVelocity(X_a_b, 1e-7);
-	MotionVecd V_a_c = transformVelocity(X_a_c, 1e-7);
+	MotionVecd V_a_b = transformVelocity(X_a_b);
+	MotionVecd V_a_c = transformVelocity(X_a_c);
 
 	BOOST_CHECK_SMALL((V_a_b.angular() - rotationVelocity(X_a_b.rotation())).norm(), TOL);
 	BOOST_CHECK_SMALL((V_a_b.linear() - X_a_b.translation()).norm(), TOL);
 	BOOST_CHECK_SMALL((V_a_c.angular() - rotationVelocity(X_a_c.rotation())).norm(), TOL);
 	BOOST_CHECK_SMALL((V_a_c.linear() - X_a_c.translation()).norm(), TOL);
 
-	MotionVecd V_b_c_a = transformError(X_a_b, X_a_c, 1e-7);
-	Vector3d w_b_c_a = rotationError(X_a_b.rotation(), X_a_c.rotation(), 1e-7);
+	MotionVecd V_b_c_a = transformError(X_a_b, X_a_c);
+	Vector3d w_b_c_a = rotationError(X_a_b.rotation(), X_a_c.rotation());
 	Vector3d v_b_c_a = X_a_c.translation() - X_a_b.translation();
 
 	BOOST_CHECK_SMALL((V_b_c_a.angular() - w_b_c_a).norm(), TOL);


### PR DESCRIPTION
This argument was not used in the function body and thus ineffective. Function calls with this parameter would suggest it has some effect, so I propose we remove it altogether.

I will open related PRs for projects that had it (e.g. RBDyn and Tasks).