### PR TITLE
Option for SIMD compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ option(PYTHON_BINDING_USER_INSTALL "Install the Python bindings in user space" O
 option(PYTHON_BINDING_FORCE_PYTHON3 "Use pip3/python3 instead of pip/python" OFF)
 option(DISABLE_TESTS "Disable unit tests." OFF)
 option(BENCHMARKS "Generate benchmark." OFF)
+option(ENABLE_SIMD "Build with all SIMD instructions on the current local machine" OFF)
 
 SET(Eigen_REQUIRED "eigen3 >= 3.2.0")
 SEARCH_FOR_EIGEN()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,22 @@ set(HEADERS SpaceVecAlg/MotionVec.h
 # !!! Don't link against it !!!
 add_library(SpaceVecAlg ${SOURCES} ${HEADERS})
 
+if(ENABLE_SIMD)
+  if(MSVC)
+    target_compile_options(SpaceVecAlg PUBLIC /arch:SSE2 /arch:AVX /arch:AVX2)
+  elseif(CMAKE_COMPILER_IS_GNUCXX)
+    execute_process(
+      COMMAND ${CMAKE_CXX_COMPILER} -dumpfullversion -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+    set(CXX_COMPILER_VERSION ${GCC_VERSION})
+    target_compile_options(SpaceVecAlg PUBLIC -march=native)
+    if(GCC_VERSION VERSION_GREATER 7.0)
+      target_compile_options(SpaceVecAlg PUBLIC -faligned-new)
+    endif()
+  elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    target_compile_options(SpaceVecAlg PUBLIC -march=native -faligned-new)
+  endif()
+endif()
+
 if(DEFINED Eigen_INCLUDE_DIR)
   target_include_directories(SpaceVecAlg SYSTEM INTERFACE "${Eigen_INCLUDE_DIR}")
 else()


### PR DESCRIPTION
In some of my projects I am using Eigen compiled with SIMD instructions (`-march=native`) and as such I need your library compiled with the same instructions. This PR adds a CMake option to do so: disabled by default to not break anything.