### PR TITLE
Inverse right Jacobian on SO(3) and its derivative

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -85,10 +85,6 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 150
 PenaltyReturnTypeOnItsOwnLine: 300
 PointerAlignment: Middle
-RawStringFormats:
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
 ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: true

--- a/src/SpaceVecAlg/MathFunc.h
+++ b/src/SpaceVecAlg/MathFunc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2012-2021 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #pragma once
@@ -12,7 +12,6 @@ namespace sva
 
 namespace details
 {
-
 template<typename T>
 T constexpr sqrtNewtonRaphson(T x, T curr, T prev)
 {
@@ -25,12 +24,158 @@ T constexpr sqrtNewtonRaphson(T x, T curr, T prev)
  *   - For a finite and non-negative value of "x", returns an approximation for the square root of "x"
  *   - Otherwise, returns NaN
  * Copied from https://stackoverflow.com/a/34134071
+ *
+ * \note Should not be used for value x such that x+1==x or x+1==1 in floating point arithmetic.
+ * \internal This limitation could be alleviated by giving a better initial guess. Finding the closest 100^n to x and
+ * starting with 10^n could be a way to go.
  */
 template<typename T>
 T constexpr sqrt(T x)
 {
   return x >= static_cast<T>(0) && x < std::numeric_limits<T>::infinity() ? sqrtNewtonRaphson(x, x, static_cast<T>(0))
                                                                           : std::numeric_limits<T>::quiet_NaN();
+}
+
+template<typename T>
+bool constexpr eq(T x, T y)
+{
+  return x < y ? (y - x) <= y * std::numeric_limits<T>::epsilon() : (x - y) <= x * std::numeric_limits<T>::epsilon();
+}
+
+template<typename T>
+T constexpr cbrtNewtonRaphson(T x, T curr, T prev)
+{
+  return eq(curr, prev)
+             ? curr
+             : cbrtNewtonRaphson(x, (static_cast<T>(2) * curr + x / (curr * curr)) / static_cast<T>(3), curr);
+}
+
+template<typename T>
+T constexpr cbrtSub(T x)
+{
+  return x < std::numeric_limits<T>::infinity() ? cbrtNewtonRaphson(x, sqrt(x), static_cast<T>(0))
+                                                : std::numeric_limits<T>::quiet_NaN();
+}
+
+/**
+ * Constexpr version of the cubic root
+ * Return value:
+ *   - For a finite of "x", returns an approximation for the cubic root of "x"
+ *   - Otherwise, returns NaN
+ * \note Should not be used for value x such that x+1==x or x+1==1 in floating point arithmetic.
+ * \internal The limitation derives from the one on sqrt.
+ */
+template<typename T>
+T constexpr cbrt(T x)
+{
+  return x >= static_cast<T>(0) ? cbrtSub(x) : -cbrtSub(-x);
+}
+
+/** Compute the value \f$ \frac{1}{x^2} - \frac{1+\cos(x)}{2 x \sin(x)} \f$.
+ */
+template<typename T>
+inline T SO3JacF2(const T & x)
+{
+  // Taylor expansion at 0 is 1/360 * (1 + x^2/60 + x^4/2520 + x^6/100800 + x^8/3991680)
+  using details::cbrt;
+  using details::sqrt;
+  constexpr T ulp = std::numeric_limits<T>::epsilon();
+  constexpr T taylor_2_bound = sqrt(static_cast<T>(60) * ulp);
+  constexpr T taylor_4_bound = sqrt(sqrt(static_cast<T>(2520) * ulp));
+  constexpr T taylor_6_bound = sqrt(cbrt(static_cast<T>(100800) * ulp));
+  constexpr T taylor_8_bound = sqrt(sqrt(sqrt(static_cast<T>(3991680) * ulp)));
+
+  double absx = std::abs(x);
+  if(absx >= taylor_8_bound)
+  {
+    return static_cast<T>(1) / (x * x) - (static_cast<T>(1) + std::cos(x)) / (static_cast<T>(2) * x * std::sin(x));
+  }
+  else
+  {
+    // approximation by taylor series in x at 0 up to order 0
+    T result = static_cast<T>(1);
+
+    if(absx >= taylor_2_bound)
+    {
+      T x2 = x * x;
+      // approximation by taylor series in x at 0 up to order 2
+      result += x2 / static_cast<T>(60);
+
+      if(absx >= taylor_4_bound)
+      {
+        T x4 = x2 * x2;
+        // approximation by taylor series in x at 0 up to order 4
+        result += x4 / static_cast<T>(2520);
+        if(absx >= taylor_6_bound)
+        {
+          // approximation by taylor series in x at 0 up to order 6
+          result += (x2 * x4) / static_cast<T>(100800);
+        }
+      }
+    }
+
+    return result / static_cast<T>(12);
+  }
+}
+
+/** Compute the value \f$ \frac{x + \sin(x)}{2x^2(1-\cos(x)} - \frac{2}{x^3}\f$
+ * which is the derivative of \f$ \frac{1}{x^2} - \frac{1+\cos(x)}{2 x \sin(x)} \f$.
+ */
+template<typename T>
+inline T dSO3JacF2(const T & x)
+{
+  // Taylor expansion at 0 is x/360 * (1 + x^2/21 + x^4/560 + x^6/16632 + (691*x^8)/363242880) + x^10/17297280 +
+  // (3617*x^12)/2117187072000 We need to go this far in the Taylor expansion, because for numbers around
+  // taylor_8_bound, the analytical formula gives a relative error of about 1e-6 with doubles, which is too high. Going
+  // up to 13th order gives us a max error of about 3e-10.
+  using details::cbrt;
+  using details::sqrt;
+  constexpr T ulp = std::numeric_limits<T>::epsilon();
+  constexpr T taylor_2_bound = sqrt(static_cast<T>(21) * ulp);
+  constexpr T taylor_4_bound = sqrt(sqrt(static_cast<T>(560) * ulp));
+  constexpr T taylor_6_bound = sqrt(cbrt(static_cast<T>(16632) * ulp));
+  constexpr T taylor_8_bound = sqrt(sqrt(sqrt(static_cast<T>(363242880) * ulp / static_cast<T>(691))));
+  constexpr T taylor_12_bound = sqrt(sqrt(cbrt(static_cast<T>(2117187072000) * ulp / static_cast<T>(3617))));
+
+  double absx = std::abs(x);
+  if(absx >= taylor_12_bound)
+  {
+    T x2 = x * x;
+    return (x + std::sin(x)) / (static_cast<T>(2) * x2 * (1 - std::cos(x))) - static_cast<T>(2) / (x2 * x);
+  }
+  else
+  {
+    // approximation by taylor series in x at 0 up to order 1
+    T result = static_cast<T>(1);
+
+    if(absx >= taylor_2_bound)
+    {
+      T x2 = x * x;
+      // approximation by taylor series in x at 0 up to order 3
+      result += x2 / static_cast<T>(21);
+
+      if(absx >= taylor_4_bound)
+      {
+        T x4 = x2 * x2;
+        // approximation by taylor series in x at 0 up to order 5
+        result += x4 / static_cast<T>(560);
+        if(absx >= taylor_6_bound)
+        {
+          // approximation by taylor series in x at 0 up to order 7
+          result += (x2 * x4) / static_cast<T>(16632);
+
+          if(absx >= taylor_8_bound)
+          {
+            T x8 = x4 * x4;
+            // approximation by taylor series in x at 0 up to order 11
+            result += (static_cast<T>(691) * x8) / static_cast<T>(363242880) + (x2 * x8) / static_cast<T>(17297280);
+          }
+        }
+      }
+    }
+
+    return x * result / static_cast<T>(360);
+  }
 }
 
 } // namespace details
@@ -91,7 +236,7 @@ T sinc_inv(const T x)
   //     6    360
   // this approximation is valid around 0.
   // if x is far from 0, our approximation is not valid
-  // since x^6 becomes non neglectable we use the normal computation of the function
+  // since x^6 becomes non negligible we use the normal computation of the function
   // (i.e. taylor_2_bound^6 + taylor_0_bound == taylor_0_bound but
   //       taylor_n_bound^6 + taylor_0_bound != taylor_0).
 
@@ -101,7 +246,7 @@ T sinc_inv(const T x)
   }
   else
   {
-    // x is bellow taylor_n_bound so we don't care of the 6th order term of
+    // x is below taylor_n_bound so we don't care about the 6th order term of
     // the taylor series.
     // We set the 0 order term.
     T result = static_cast<T>(1);
@@ -114,13 +259,86 @@ T sinc_inv(const T x)
 
       if(std::abs(x) >= taylor_2_bound)
       {
-        // x is upper the machine sqrt(epsilon) so x^4 is meaningful.
+        // x is above the machine sqrt(epsilon) so x^4 is meaningful.
         result += static_cast<T>(7) * (x2 * x2) / static_cast<T>(360);
       }
     }
 
     return (result);
   }
+}
+
+/** Inverse of the right Jacobian of SO(3) as defined in
+ * "A micro Lie theory for state estimation in robotics" by Solà et al. (see in particular eq. 144)
+ *
+ * Inverse of left Jacobian is simply obtained by transposing (see eq. 147)
+ *
+ * sva::rotationError(X,Y) is such that is derivative wrt X is \f$ J_r^{-1} \f$ as given by this function and
+ * its derivative wrt Y is \f$ -J_r^{-T} \f$.
+ *
+ * \param u Point of so(3) at which to compute the matrix.
+ */
+template<typename T>
+Eigen::Matrix3<T> SO3RightJacInv(const Eigen::Vector3<T> & u)
+{
+  auto nu = u.norm();
+
+  Eigen::Matrix3<T> C2;
+  auto f2 = details::SO3JacF2(nu);
+  auto xx = f2 * u.x() * u.x();
+  auto xy = f2 * u.x() * u.y();
+  auto xz = f2 * u.x() * u.z();
+  auto yy = f2 * u.y() * u.y();
+  auto yz = f2 * u.y() * u.z();
+  auto zz = f2 * u.z() * u.z();
+  // clang-format off
+  C2 << -yy - zz,    xy   ,    xz, 
+           xy   , -xx - zz,    yz,
+           xz   ,    yz   , -xx - yy;
+  // clang-format on
+
+  Eigen::Matrix3<T> C = vector3ToCrossMatrix(Eigen::Vector3<T>(u / 2));
+
+  return Eigen::Matrix3<T>::Identity() + C + C2;
+}
+
+/** Derivative w.r.t. time of Inverse of the right Jacobian of SO(3)
+ *
+ * \param u Point of so(3) at which to compute the matrix.
+ * \param du Derivative w.r.t. time of \p u.
+ */
+template<typename T>
+Eigen::Matrix3<T> SO3RightJacInvDot(const Eigen::Vector3<T> & u, const Eigen::Vector3<T> & du)
+{
+  auto nu = u.norm();
+  Eigen::Matrix3<T> C2;
+  Eigen::Matrix3<T> C3;
+  auto f2 = details::SO3JacF2(nu);
+  auto df2 = (u.dot(du) / nu) * details::dSO3JacF2(nu);
+  auto xx = df2 * u.x() * u.x();
+  auto xy = df2 * u.x() * u.y();
+  auto xz = df2 * u.x() * u.z();
+  auto yy = df2 * u.y() * u.y();
+  auto yz = df2 * u.y() * u.z();
+  auto zz = df2 * u.z() * u.z();
+  auto dxx = 2 * f2 * du.x() * u.x();
+  auto dyy = 2 * f2 * du.y() * u.y();
+  auto dzz = 2 * f2 * du.z() * u.z();
+  auto c12 = f2 * (du.y() * u.x() + du.x() * u.y());
+  auto c13 = f2 * (du.z() * u.x() + du.x() * u.z());
+  auto c23 = f2 * (du.z() * u.y() + du.y() * u.z());
+  // clang-format off
+  C2 << -yy - zz,    xy   ,    xz, 
+           xy   , -xx - zz,    yz,
+           xz   ,    yz   , -xx - yy;
+  C3 << -dyy - dzz,    c12    ,     c13, 
+           c12    , -dxx - dzz,     c23,
+           c13    ,    c23    , -dxx - dyy;
+  // clang-format on
+
+  Eigen::Matrix3<T> C = vector3ToCrossMatrix(Eigen::Vector3<T>(du / 2));
+
+  return C + C2 + C3;
 }
 
 } // namespace sva

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,5 +31,6 @@ addUnitTest("InertiaTest")
 addUnitTest("PTransformTest")
 addUnitTest("AutoDiffTest")
 addUnitTest("ConversionsTest")
+addUnitTest("LogDiffTest")
 
 addBenchmark("PTransformBench")

--- a/tests/LogDiffTest.cpp
+++ b/tests/LogDiffTest.cpp
@@ -27,12 +27,12 @@ BOOST_AUTO_TEST_CASE(Cbrt)
 {
   auto testd = [](double x, double eps = std::numeric_limits<double>::epsilon()) {
     double y = details::cbrt(x);
-    BOOST_CHECK_SMALL((y * y * y - x), 2 * std::abs(x) * eps);
+    BOOST_CHECK_LE((y * y * y - x), 2 * std::abs(x) * eps);
   };
 
   auto testf = [](float x, float eps = std::numeric_limits<float>::epsilon()) {
     float y = details::cbrt(x);
-    BOOST_CHECK_SMALL((y * y * y - x), 2 * std::abs(x) * eps);
+    BOOST_CHECK_LE((y * y * y - x), 2 * std::abs(x) * eps);
   };
 
   for(int i = -12; i <= 12; ++i) testd(std::pow(10., i));
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(SO3JacF2)
     BOOST_CHECK_SMALL(std::abs(f2 - res) / res, eps);
   };
 
-  auto testf = [](float x, float res, float eps = std::numeric_limits<float>::epsilon()) {
+  auto testf = [](float x, float res, float eps = 4 * std::numeric_limits<float>::epsilon()) {
     float f2 = details::SO3JacF2(x);
     BOOST_CHECK_SMALL(std::abs(f2 - res) / res, eps);
     f2 = details::SO3JacF2(-x);
@@ -154,9 +154,6 @@ BOOST_AUTO_TEST_CASE(SO3RightJacInvTest)
     assert(std::abs(R2.determinant() - 1) < 1e-14); // of -(-1)^n with n the size of the matrix. However this is
                                                     // implementation-dependent, so we keep the check.
 #endif
-
-    Matrix4d R3 = Matrix4d::Random().householderQr().householderQ();
-    std::cout << R3.determinant() << std::endl;
 
     // Computations are getting less precise as we approach the singularity of the log for a rotation angle of pi.
     // We skip those cases so that we can keep a tight bound on the precision of the remaining tests.

--- a/tests/LogDiffTest.cpp
+++ b/tests/LogDiffTest.cpp
@@ -144,8 +144,20 @@ BOOST_AUTO_TEST_CASE(SO3RightJacInvTest)
 {
   for(int i = 0; i < 1000; ++i)
   {
+#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
     Matrix3d R1 = Quaterniond::UnitRandom().toRotationMatrix();
     Matrix3d R2 = Quaterniond::UnitRandom().toRotationMatrix();
+#else
+    Matrix3d R1 = Matrix3d::Random().householderQr().householderQ();
+    Matrix3d R2 = Matrix3d::Random().householderQr().householderQ();
+    assert(std::abs(R1.determinant() - 1) < 1e-14); // We use the fact that the QR implementation gives a determinant
+    assert(std::abs(R2.determinant() - 1) < 1e-14); // of -(-1)^n with n the size of the matrix. However this is
+                                                    // implementation-dependent, so we keep the check.
+#endif
+
+    Matrix4d R3 = Matrix4d::Random().householderQr().householderQ();
+    std::cout << R3.determinant() << std::endl;
+
     // Computations are getting less precise as we approach the singularity of the log for a rotation angle of pi.
     // We skip those cases so that we can keep a tight bound on the precision of the remaining tests.
     // This loss of precision is not a problem in practice because (i) in the target applications of sva, rotation

--- a/tests/LogDiffTest.cpp
+++ b/tests/LogDiffTest.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2012-2021 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+// check memory allocation in some method
+#define EIGEN_RUNTIME_NO_MALLOC
+
+// includes
+// std
+#include <iostream>
+
+// boost
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE LogDiff test
+#include <boost/test/unit_test.hpp>
+
+// SpaceVecAlg
+#include <SpaceVecAlg/SpaceVecAlg>
+
+// Exponential of matrices
+#include <unsupported/Eigen/MatrixFunctions>
+
+using namespace sva;
+using namespace Eigen;
+
+BOOST_AUTO_TEST_CASE(Cbrt)
+{
+  auto testd = [](double x, double eps = std::numeric_limits<double>::epsilon()) {
+    double y = details::cbrt(x);
+    BOOST_CHECK_SMALL((y * y * y - x), 2 * std::abs(x) * eps);
+  };
+
+  auto testf = [](float x, float eps = std::numeric_limits<float>::epsilon()) {
+    float y = details::cbrt(x);
+    BOOST_CHECK_SMALL((y * y * y - x), 2 * std::abs(x) * eps);
+  };
+
+  for(int i = -12; i <= 12; ++i) testd(std::pow(10., i));
+  for(int i = -12; i <= 12; ++i) testd(-std::pow(10., i));
+  testd(0);
+  for(int i = -6; i <= 6; ++i) testf(std::pow(10.f, static_cast<float>(i)));
+  for(int i = -6; i <= 6; ++i) testf(-std::pow(10.f, static_cast<float>(i)));
+  testf(0);
+}
+
+BOOST_AUTO_TEST_CASE(SO3JacF2)
+{
+  auto testd = [](double x, double res, double eps = std::numeric_limits<double>::epsilon()) {
+    double f2 = details::SO3JacF2(x);
+    BOOST_CHECK_SMALL(std::abs(f2 - res) / res, eps);
+    f2 = details::SO3JacF2(-x);
+    BOOST_CHECK_SMALL(std::abs(f2 - res) / res, eps);
+  };
+
+  auto testf = [](float x, float res, float eps = std::numeric_limits<float>::epsilon()) {
+    float f2 = details::SO3JacF2(x);
+    BOOST_CHECK_SMALL(std::abs(f2 - res) / res, eps);
+    f2 = details::SO3JacF2(-x);
+    BOOST_CHECK_SMALL(std::abs(f2 - res) / res, eps);
+  };
+
+  // Ground truth numbers were computed with matlab vpa function and 50 digits precision.
+  testd(2, 0.0894768460164173242483950);
+  // The two next computations do not use the taylor approximation yet, but are subtracting numbers quite close, hence a
+  // small loss of accuracy
+  testd(1., 0.0847561391437740403659902, 5e-16);
+  testd(1e-1, 0.0833472255299274574976738, 1e-13);
+  testd(1e-2, 0.0833334722225529108796317);
+  testd(1e-3, 0.0833333347222222552910061);
+  testd(1e-4, 0.0833333333472222222255291);
+  testd(1e-5, 0.0833333333334722222222225);
+  testd(1e-6, 0.0833333333333347222222222);
+  testd(1e-7, 0.0833333333333333472222222);
+  testd(1e-8, 0.0833333333333333334722222);
+  testd(1e-9, 0.0833333333333333333347222);
+  testd(1e-10, 0.0833333333333333333333472);
+
+  testf(2.f, 0.0894768460164173242483950f);
+  testf(1.f, 0.0847561391437740403659902f);
+  testf(1e-1f, 0.0833472255299274574976738f);
+  testf(1e-2f, 0.0833334722225529108796317f);
+  testf(1e-3f, 0.0833333347222222552910061f);
+  testf(1e-4f, 0.0833333333472222222255291f);
+  testf(1e-5f, 0.0833333333334722222222225f);
+  testf(1e-6f, 0.0833333333333347222222222f);
+  testf(1e-7f, 0.0833333333333333472222222f);
+  testf(1e-8f, 0.0833333333333333334722222f);
+  testf(1e-9f, 0.0833333333333333333347222f);
+  testf(1e-10f, 0.0833333333333333333333472f);
+}
+
+BOOST_AUTO_TEST_CASE(dSO3JacF2)
+{
+  std::cout.precision(17);
+  auto testd = [](double x, double res, double eps = std::numeric_limits<double>::epsilon()) {
+    double f2 = details::dSO3JacF2(x);
+    BOOST_CHECK_SMALL(std::abs(f2 - res) / res, eps);
+    f2 = -details::dSO3JacF2(-x);
+    BOOST_CHECK_SMALL(std::abs(f2 - res) / res, eps);
+  };
+
+  auto testf = [](float x, float res, float eps = std::numeric_limits<float>::epsilon()) {
+    float f2 = details::dSO3JacF2(x);
+    BOOST_CHECK_SMALL(std::abs(f2 - res) / res, eps);
+    f2 = -details::dSO3JacF2(-x);
+    BOOST_CHECK_SMALL(std::abs(f2 - res) / res, eps);
+  };
+
+  // Ground truth numbers were computed with matlab vpa function and 100 digits precision (50 is not enough for the
+  // smallest entries).
+
+  testd(2., 0.00679694292146532720196937, 1e-14);
+  testd(1., 0.0029151856912366650224031, 1e-13);
+  // This is about the worst scenario: 0.267 ~ taylor_12_bound, but still using the general formula that subtract two
+  // close numbers
+  testd(0.267, 0.000744191160073626215859056, 3e-10);
+  testd(1e-1, 0.000277910102529934204614325);
+  testd(0.058, 0.0001611369228328263168718797); // 0.058 ~ taylor_8_bound
+  testd(1e-2, 0.0000277779100534060863262305);
+  testd(1e-3, 0.00000277777791005291501322768);
+  testd(1e-4, 0.000000277777777910052910102513);
+  testd(1e-5, 0.0000000277777777779100529100534, 3e-16);
+  testd(1e-6, 0.00000000277777777777791005291005);
+  testd(1e-7, 0.000000000277777777777777910052910);
+  testd(1e-8, 0.0000000000277777777777777779100529);
+  testd(1e-9, 0.00000000000277777777777777777791005);
+  testd(1e-10, 0.000000000000277777777777777777777910);
+
+  testf(2.f, 0.00679694292146532720196937f, 3e-6f);
+  testf(1.f, 0.0029151856912366650224031f);
+  testf(1e-1f, 0.000277910102529934204614325f);
+  testf(1e-2f, 0.0000277779100534060863262305f);
+  testf(1e-3f, 0.00000277777791005291501322768f);
+  testf(1e-4f, 0.000000277777777910052910102513f);
+  testf(1e-5f, 0.0000000277777777779100529100534f);
+  testf(1e-6f, 0.00000000277777777777791005291005f);
+  testf(1e-7f, 0.000000000277777777777777910052910f);
+  testf(1e-8f, 0.0000000000277777777777777779100529f);
+  testf(1e-9f, 0.00000000000277777777777777777791005f);
+  testf(1e-10f, 0.000000000000277777777777777777777910f);
+}
+
+BOOST_AUTO_TEST_CASE(SO3RightJacInvTest)
+{
+  for(int i = 0; i < 10; ++i)
+  {
+    Matrix3d R1 = Quaterniond::UnitRandom().toRotationMatrix();
+    Matrix3d R2 = Quaterniond::UnitRandom().toRotationMatrix();
+    Matrix3d I = Matrix3d::Identity();
+    double h = 1e-8;
+
+    Vector3d u0 = rotationError(R1, R2);
+    auto invJr = SO3RightJacInv(u0);
+
+    // Finite differences for f(X,Y) = rotationError(X, Y)
+    // Jd1 is Df/DX, Jd2 is Df/DY
+    Matrix3d J1d, J2d;
+    for(int i = 0; i < 3; ++i)
+    {
+      // R1 "+" h e_i
+      Matrix3d R1p = R1 * vector3ToCrossMatrix(Vector3d(h * I.col(i))).exp();
+      // R2 "+" h e_i
+      Matrix3d R2p = R2 * vector3ToCrossMatrix(Vector3d(h * I.col(i))).exp();
+      J1d.col(i) = (rotationError(R1p, R2) - u0) / h; // ( f(R1 "+" h e_i, R2) "-" f(R1,R2) ) / h
+      J2d.col(i) = (rotationError(R1, R2p) - u0) / h; // ( f(R1, R2 "+" h e_i) "-" f(R1,R2) ) / h
+    }
+
+    BOOST_CHECK_SMALL((J1d - invJr).norm(), 5e-6); // Df/DX = Jr^-1
+    BOOST_CHECK_SMALL((J2d + invJr.transpose()).norm(), 5e-6); // Df/DY = -Jl^-1 = -Jr^-T
+  }
+}
+
+BOOST_AUTO_TEST_CASE(SO3RightJacInvDotTest)
+{
+  for(int i = 0; i < 10; ++i)
+  {
+    Vector3d u0 = Vector3d::Random();
+    Vector3d du = Vector3d::Random();
+
+    double dt = 1e-8;
+    Matrix3d M0 = SO3RightJacInv(u0);
+    Matrix3d Mt = SO3RightJacInv(Vector3d(u0 + dt * du));
+    Matrix3d dM = (Mt - M0) / dt;
+    Matrix3d J0 = SO3RightJacInvDot(u0, du);
+
+    BOOST_CHECK_SMALL((dM - J0).norm(), 1e-6);
+  }
+}


### PR DESCRIPTION
This adds the computation around  `J_r^-1`, the inverse of the right Jacobian for SO(3) as defined in "A micro Lie theory for state estimation in robotics" by Solà et al.

This is an important matrix, necessary to compute the Jacobian of the log on SO(3).