### PR TITLE
Fixing rotationVelocity when the rotation angle is close to pi

### DIFF
--- a/src/SpaceVecAlg/PTransform.h
+++ b/src/SpaceVecAlg/PTransform.h
@@ -293,12 +293,27 @@ inline Eigen::Vector3<T> rotationError(const Eigen::Matrix3<T> & E_a_b, const Ei
 template<typename T>
 inline Eigen::Vector3<T> rotationVelocity(const Eigen::Matrix3<T> & E_a_b)
 {
-  Eigen::Vector3<T> w;
-  T acosV = (E_a_b(0, 0) + E_a_b(1, 1) + E_a_b(2, 2) - 1.) * 0.5;
+  constexpr T eps = std::numeric_limits<T>::epsilon();
+  constexpr T sqeps = details::sqrt(eps);
+  constexpr T sqsqeps = details::sqrt(sqeps);
+
+  T trace = E_a_b(0, 0) + E_a_b(1, 1) + E_a_b(2, 2);
+  T acosV = (trace - 1.) * 0.5;
   T theta = std::acos(std::min(std::max(acosV, -1.), 1.));
 
-  w = Eigen::Vector3<T>(-E_a_b(2, 1) + E_a_b(1, 2), -E_a_b(0, 2) + E_a_b(2, 0), -E_a_b(1, 0) + E_a_b(0, 1));
-  w *= sinc_inv(theta) * 0.5;
+  Eigen::Vector3<T> w(-E_a_b(2, 1) + E_a_b(1, 2), -E_a_b(0, 2) + E_a_b(2, 0), -E_a_b(1, 0) + E_a_b(0, 1));
+
+  if(1 + trace < sqsqeps) // in case of angle close to pi
+  {
+    // adapted from https://vision.in.tum.de/_media/members/demmeln/nurlanov2021so3log.pdf, sec2.2
+    Eigen::Vector3<T> s = (2 * E_a_b.diagonal() + Eigen::Vector3<T>::Constant(1 - trace)) / (3 - trace);
+    Eigen::Vector3<T> tn2 = theta * s.cwiseSqrt();
+    return (w.array() >= 0).select(tn2, -tn2);
+  }
+  else
+  {
+    w *= sinc_inv(theta) * 0.5;
+  }
 
   return w;
 }

--- a/src/SpaceVecAlg/PTransform.h
+++ b/src/SpaceVecAlg/PTransform.h
@@ -296,6 +296,7 @@ inline Eigen::Vector3<T> rotationVelocity(const Eigen::Matrix3<T> & E_a_b)
   constexpr T eps = std::numeric_limits<T>::epsilon();
   constexpr T sqeps = details::sqrt(eps);
   constexpr T sqsqeps = details::sqrt(sqeps);
+  constexpr T pi = 3.1415926535897932;
 
   T trace = E_a_b(0, 0) + E_a_b(1, 1) + E_a_b(2, 2);
   T acosV = (trace - 1.) * 0.5;
@@ -308,6 +309,31 @@ inline Eigen::Vector3<T> rotationVelocity(const Eigen::Matrix3<T> & E_a_b)
     // adapted from https://vision.in.tum.de/_media/members/demmeln/nurlanov2021so3log.pdf, sec2.2
     Eigen::Vector3<T> s = (2 * E_a_b.diagonal() + Eigen::Vector3<T>::Constant(1 - trace)) / (3 - trace);
     Eigen::Vector3<T> tn2 = theta * s.cwiseSqrt();
+    // If theta is really close to pi the sign of n is derived from (13)
+    // We choose the first non-zero coefficient to be positive arbitrarly
+    if(theta > pi - 1e-7)
+    {
+      if(tn2(0) > 0)
+      {
+        if(E_a_b(0, 1) + E_a_b(1, 0) < 0)
+        {
+          tn2(1) = -tn2(1);
+        }
+        if(E_a_b(0, 2) + E_a_b(2, 0) < 0)
+        {
+          tn2(2) = -tn2(2);
+        }
+      }
+      else if(tn2(1) > 0) // only if tn2(0) == 0
+      {
+        if(E_a_b(1, 2) + E_a_b(2, 1) < 0)
+        {
+          tn2(2) = -tn2(2);
+        }
+      }
+      return tn2;
+    }
+    // The sign is derived from (9)
     return (w.array() >= 0).select(tn2, -tn2);
   }
   else

--- a/tests/PTransformTest.cpp
+++ b/tests/PTransformTest.cpp
@@ -457,17 +457,45 @@ BOOST_AUTO_TEST_CASE(rotationVelocityTest)
     }
   }
 
-  // Tests for rotations with angle close to pi
-  for(int i = 0; i < 5; ++i)
+  auto check_pi_rotation = [](const Eigen::Vector3d & u, double e) {
+    Matrix3d r1 = AngleAxisd(constants::pi<double>() + std::pow(10, e), u).toRotationMatrix();
+    Matrix3d r2 = AngleAxisd(constants::pi<double>() - std::pow(10, e), u).toRotationMatrix();
+    BOOST_CHECK(vector3ToCrossMatrix(rotationVelocity(r1)).exp().transpose().isApprox(r1, 1e-6));
+    BOOST_CHECK(vector3ToCrossMatrix(rotationVelocity(r2)).exp().transpose().isApprox(r2, 1e-6));
+  };
+
+  // Tests for rotations around unit axes with angle close to pi
+  for(double e = -2; e > -16; e -= .5)
+  {
+    check_pi_rotation(Eigen::Vector3d::UnitX(), e);
+    check_pi_rotation(Eigen::Vector3d::UnitY(), e);
+    check_pi_rotation(Eigen::Vector3d::UnitZ(), e);
+  }
+
+  // Tests for random rotations with angle close to pi
+  for(int i = 0; i < 1000; ++i)
   {
     for(double e = -2; e > -16; e -= .5)
     {
       Vector3d rd = Vector3d::Random();
       Vector3d u = rd.normalized();
-      Matrix3d r1 = AngleAxisd(constants::pi<double>() + std::pow(10, e), u).toRotationMatrix();
-      Matrix3d r2 = AngleAxisd(constants::pi<double>() - std::pow(10, e), u).toRotationMatrix();
-      BOOST_CHECK(vector3ToCrossMatrix(rotationVelocity(r1)).exp().transpose().isApprox(r1, 1e-6));
-      BOOST_CHECK(vector3ToCrossMatrix(rotationVelocity(r2)).exp().transpose().isApprox(r2, 1e-6));
+      check_pi_rotation(u, e);
     }
+  }
+
+  auto check_exact_pi_rotation = [](const Eigen::Vector3d & u) {
+    Matrix3d r1 = AngleAxisd(constants::pi<double>(), u).toRotationMatrix();
+    BOOST_CHECK(vector3ToCrossMatrix(rotationVelocity(r1)).exp().transpose().isApprox(r1, 1e-6));
+  };
+  // Tests for rotations around unit axes with angle equal to pi
+  check_exact_pi_rotation(Eigen::Vector3d::UnitX());
+  check_exact_pi_rotation(Eigen::Vector3d::UnitY());
+  check_exact_pi_rotation(Eigen::Vector3d::UnitZ());
+  // Tests for random rotations with angle equal to pi
+  for(int i = 0; i < 10000; ++i)
+  {
+    Vector3d rd = Vector3d::Random();
+    Vector3d u = rd.normalized();
+    check_exact_pi_rotation(u);
   }
 }


### PR DESCRIPTION
This fixes `rotationVelocity` when the rotation angle is close to pi.