### PR TITLE
[tests] Relax test precision on PTransform.sinc_inv

### DIFF
--- a/binding/python/tests/test_sva_ptransform.py
+++ b/binding/python/tests/test_sva_ptransform.py
@@ -205,17 +205,18 @@ class Testsinc_inv(unittest.TestCase):
     t = -1.
     nrIter = 333
     for i in range(nrIter):
-      self.assertEqual(dummy_sinc_inv(t), sva.sinc_inv(t))
+      self.assertAlmostEqual(dummy_sinc_inv(t), sva.sinc_inv(t), delta= TOL)
       t += 2./nrIter
 
     self.assertTrue(np.isnan(dummy_sinc_inv(0)))
     self.assertEqual(sva.sinc_inv(0), 1)
 
-    self.assertEqual(dummy_sinc_inv(eps), sva.sinc_inv(eps))
-    self.assertEqual(dummy_sinc_inv(np.sqrt(eps)),
-                     sva.sinc_inv(np.sqrt(eps)))
-    self.assertEqual(dummy_sinc_inv(np.sqrt(np.sqrt(eps))),
-                     sva.sinc_inv(np.sqrt(np.sqrt(eps))))
+    self.assertAlmostEqual(dummy_sinc_inv(eps), sva.sinc_inv(eps), delta = TOL)
+
+    self.assertAlmostEqual(dummy_sinc_inv(np.sqrt(eps)),
+                     sva.sinc_inv(np.sqrt(eps)), delta = TOL)
+    self.assertAlmostEqual(dummy_sinc_inv(np.sqrt(np.sqrt(eps))),
+                     sva.sinc_inv(np.sqrt(np.sqrt(eps))), delta = TOL)
 
 if __name__ == "__main__":
   suite = unittest.TestSuite()


### PR DESCRIPTION
Following #43 the `PTransform.sinc_inv` test no longer passes on `Ubuntu 20.04` due to the test itself checking with too high floating point precision (differences occur at the 1e-15). This PR relaxes the test to the tolerance commonly used throughout the other PTransform tests (`TOL = 0.00001`)

```
7: ======================================================================
7: FAIL: test (test_sva_ptransform.Testsinc_inv)
7: ----------------------------------------------------------------------
7: Traceback (most recent call last):
7:   File "/home/arnaud/src/SpaceVecAlg/build/binding/python/sva/python3/RelWithDebInfo/tests/test_sva_ptransform.py", line 208, in test
7:     self.assertEqual(dummy_sinc_inv(t), sva.sinc_inv(t))
7: AssertionError: 1.1686853919283349 != 1.168685391928335
7: 
7: ----------------------------------------------------------------------
7: Ran 19 tests in 0.046s
7: 
7: FAILED (failures=1)
7/7 Test #7: test-sva-python3-bindings ........***Failed    0.21 sec
```